### PR TITLE
Fix "a table expected, got nil" error when clicking a subList

### DIFF
--- a/DasGui.lua
+++ b/DasGui.lua
@@ -193,7 +193,7 @@ function DAS.SetSubLabels(questTable)
     label.dataQuestState    = DAS.GetQuestStatus(questName)
     label:SetHidden(false)
     if label.dataQuestState == DAS_STATUS_ACTIVE then
-      table.insert(activeZoneQuests, label.dataJournalIndex)
+      table.insert(DAS.activeZoneQuests, label.dataJournalIndex)
       status = label.dataQuestState
       elseif status ~= DAS_STATUS_ACTIVE and status ~= DAS_STATUS_OPEN then
       status = label.dataQuestState


### PR DESCRIPTION
The multiquest sublists are still broken even with this change, but at least they don't throw a NIL error due to a typo.