### PR TITLE
Use prebaked questList titles

### DIFF
--- a/DasGui.lua
+++ b/DasGui.lua
@@ -170,10 +170,15 @@ function setLabelTable(questTable)
   return questName, status
 end
 local sep = "%s%w%w%s"
-local function makeSubLabelTitle(str, str2)
+local function makeSubLabelTitle(str, zoneId, listIndex)
+  if zoneId ~= nil and DAS.QuestListTitles[zoneId] ~= nil then
+    if DAS.QuestListTitles[zoneId][listIndex] ~= nil then
+        return DAS.QuestListTitles[zoneId][listIndex] .. "..."
+    end
+  end
   if not str then return end
   local idx = string.find(str, sep)
-  if nil == idx then return str end
+  if nil == idx then return str .. " ..." end
   return string.sub(str, 0, idx+3) .. "..."
 end
 function DAS.SetSubLabels(questTable)
@@ -214,7 +219,8 @@ function DAS.SetSubLabels(questTable)
 end
 local typeTable = "table"
 function DAS.setLabels(zoneQuests)
-  zoneQuests = zoneQuests or DAS.GetZoneQuests()
+  local zoneId = zoneId or DAS.GetZoneId()
+  zoneQuests = zoneQuests or DAS.GetZoneQuests(zoneId)
   labelTexts = {}
   -- p("DAS.setLabels")
   DAS.activeZoneQuests = {}
@@ -230,7 +236,7 @@ function DAS.setLabels(zoneQuests)
           label.dataQuestList 	          = ZO_DeepTableCopy(questNameOrTable, {})
           label.dataQuestName, status     = setLabelTable(questNameOrTable)
           label.dataQuestState            = status or DAS_STATUS_OPEN
-          label.dataTitle                 = makeSubLabelTitle(label.dataQuestList[1], label.dataQuestList[2]) or questName
+          label.dataTitle                 = makeSubLabelTitle(label.dataQuestList[1], zoneId, index) or questName
           else
           label.dataQuestList 	  = nil
           label.dataTitle         = questNameOrTable

--- a/locale/de.lua
+++ b/locale/de.lua
@@ -127,6 +127,7 @@ local strings  = {
 
 	-- Vvardenfell / Morrowind
 	-- Ashlander relic dailies : NPC = Numani-Rasi
+	DAS_LIST_M_RELIC        = "Die Relikte von ",
 	DAS_M_REL_YASAM         = "Die Relikte von Yasammidan",         -- 5924
 	DAS_M_REL_ASSAR         = "Die Relikte von Assarnatamat",       -- 5925
 	DAS_M_REL_MAELK         = "Die Relikte von Maelkashishi",       -- 5926

--- a/locale/en.lua
+++ b/locale/en.lua
@@ -128,6 +128,7 @@ local strings  = {
 
 	-- Vvardenfell / Morrowind
 	-- Ashlander relic dailies : NPC = Numani-Rasi
+	DAS_LIST_M_RELIC        = "Relics of ",
 	DAS_M_REL_YASAM         = "Relics of Yasammidan",      -- 5924
 	DAS_M_REL_ASSAR         = "Relics of Assarnatamat",    -- 5925
 	DAS_M_REL_MAELK         = "Relics of Maelkashishi",    -- 5926

--- a/locale/fr.lua
+++ b/locale/fr.lua
@@ -127,6 +127,7 @@ local strings  = {
 
 	-- Vvardenfell / Morrowind
 	-- Ashlander relic dailies : NPC = Numani-Rasi
+	DAS_LIST_M_RELIC        = "Reliques de ",
 	DAS_M_REL_YASAM         = "Reliques de Yasammidan",       -- 5924
 	DAS_M_REL_ASSAR         = "Reliques d'Assarnatamat",      -- 5925
 	DAS_M_REL_MAELK         = "Reliques de Maelkashishi",     -- 5926

--- a/locale/jp.lua
+++ b/locale/jp.lua
@@ -127,6 +127,7 @@ local strings  = {
 
 	-- Vvardenfell / Morrowind
 	-- Ashlander relic dailies : NPC = Numani-Rasi
+	DAS_LIST_M_RELIC        = "〇〇の遺物 ",
 	DAS_M_REL_YASAM         = "ヤサミダンの遺物", -- 5924
 	DAS_M_REL_ASSAR         = "アサルナタマットの遺物", -- 5925
 	DAS_M_REL_MAELK         = "メイルカシシの遺物", -- 5926

--- a/locale/ru.lua
+++ b/locale/ru.lua
@@ -127,6 +127,7 @@ local strings  = {
 
 	-- Vvardenfell / Morrowind
 	-- Ashlander relic dailies : NPC = Numani-Rasi
+	DAS_LIST_M_RELIC        = "Реликвии из ",
 	DAS_M_REL_YASAM         = "Реликвии из Ясаммидана",       -- 5924
 	DAS_M_REL_ASSAR         = "Реликвии из Ассарнатамата",    -- 5925
 	DAS_M_REL_MAELK         = "Реликвии из Мелкашиши",        -- 5926

--- a/questData/GuildQuests.lua
+++ b/questData/GuildQuests.lua
@@ -36,6 +36,13 @@ DAS.subLists.ud = DAS.subLists.guilds
 
 DAS.QuestLists[zoneId2]  = DAS.QuestLists[zoneId]
 DAS.QuestLists[zoneId3]  = DAS.QuestLists[zoneId]
+DAS.QuestListTitles = DAS.QuestListTitles or {}
+DAS.QuestListTitles[zoneId] = {
+	[1] = GetString(DAS_GUILD_ANCHORS),
+	[2] = GetString(DAS_GUILD_MADNESS),
+}
+DAS.QuestListTitles[zoneId2] = DAS.QuestListTitles[zoneId]
+DAS.QuestListTitles[zoneId3] = DAS.QuestListTitles[zoneId]
 local zoneIds = {
     [104] = {["fg"] = GetString(DAS_FG_ALIKR), ["mg"] = GetString(DAS_MG_ALIKR), ["ud"] = GetString(DAS_UD_ALIKR)}, -- Alik'r Desert
     [381] = {["fg"] = GetString(DAS_FG_AURID), ["mg"] = GetString(DAS_MG_AURID), ["ud"] = GetString(DAS_UD_AURID)}, -- Auridon

--- a/questData/Morrowind.lua
+++ b/questData/Morrowind.lua
@@ -42,6 +42,10 @@ DAS.QuestLists[zoneId] = {
 		[6] = GetString(DAS_M_BOSS_APPRE),
   },
 }
+DAS.QuestListTitles = DAS.QuestListTitles or {}
+DAS.QuestListTitles[zoneId] = {
+	[1] = GetString(DAS_LIST_M_RELIC),
+}
 table.insert(tbl, DAS.QuestLists[zoneId].relic)
 table.insert(tbl2, "relic")
 table.insert(tbl, GetString(DAS_M_HUNT_EATER))


### PR DESCRIPTION
The dynamic pattern matcher reliably works only for English. QuestList title is now looked up in DAS.QuestListTitles[zoneId][listIndex] table first, and falls back to dynamic matching on NIL.