### PR TITLE
Remove boilerplate comments from questData

### DIFF
--- a/questData/Blackwood.lua
+++ b/questData/Blackwood.lua
@@ -29,16 +29,6 @@ table.insert(tbl2, {[1] = "conflict", [2] = "interest", [3] = "any"})
 DAS.shareables[zoneId]      = tbl
 DAS.makeBingoTable(zoneId, tbl2)
 
--- If there are subzones, you register them like this but I don't know it it is the case:
---DAS.subzones[zoneId+1] = zoneId
---DAS.subzones[zoneId+2] = zoneId
---DAS.subzones[zoneId+3] = zoneId
-
-local zoneId = DAS.GetZoneId()
-local quests = DAS.shareables[zoneId] or DAS.shareables[DAS.subzones[zoneId]] or {}
-
--- Not checked further as i don't haveall these ID
-
 -- set up auto quest accept:
 DAS.questStarter[zoneId] = {
   [GetString(DAS_QUEST_BW_BOSS)]	= true,  -- Questgiver 1
@@ -48,15 +38,7 @@ DAS.questStarter[zoneId] = {
 DAS.questFinisher[zoneId] = {
   [GetString(DAS_QUEST_BW_BOSS)]  = true,
   [GetString(DAS_QUEST_BW_DELVE)]  = true,
-  -- fictional NPC3 just hands out, doesn't accept
 }
---[[
-  I'm matching against the quest IDs for auto accepting quest shares.
-  Reason: Comparing numbers is a tonne cheaper than comparing strings.
-  Make sure you register the quest IDs. Unfortunately, you can only see them
-  when you get a quest shared OR via iteration after yu have completed those.
--- ]]
--- Set up like below (Morrowind example):
 DAS.questIds[zoneId] = {
 	[6644]  = true, --	"A Proper Blessing",			DELVE
 	[6645]  = true, --	"Legend of the Man-Bull	",		BOSS
@@ -72,17 +54,3 @@ DAS.questIds[zoneId] = {
 	[6675]  = true, --	"Insect Savior",			DELVE
 
 }
-
--- now hook up additiona subzone IDs (like Clockwork City - Brass Citadel has its own ID
---DAS.zoneHasAdditionalId(zoneId2, zoneId)
---[[
-  Don't forget to register the zone ID in the options. If the AddOn isn't detecting active in the settings
-  for its zone ID, it won't show.
-  ..\00_startup
-  defaults.tracked[zoneId]
-  You also need to register a menu setting so users can toggle it on and off
-  ..\DASMenu.lua
-  Hook up your new quest data file in the AddOn's manifest file:
-  ..\DailyAutoShare.txt
-  ... and you're good to go.
-]]

--- a/questData/SouthElsweyr.lua
+++ b/questData/SouthElsweyr.lua
@@ -1,14 +1,6 @@
--- If I suddenly drop dead and you want to maintain this AddOn
--- specify the zone ID as local variable
 local zoneId	= 1133
--- have two local tables. The first is for quest names, the second is for the corresponding bingo codes.
 local tbl   = {}
 local tbl2  = {}
---[[
-  set up the tables. Order of quests in the UI depends on the order you add them here.
-  Important: You have to use GetString(YOUR_QUEST_NAME_CONSTANT) here, or localization won't work.
-  Localization strings are defined in ../locale/<lang>.lua
---]]
 
 -- Bruccius Baenius
 --	A Rogue and His Rice
@@ -78,30 +70,12 @@ table.insert(tbl2, {[1] = "garden", [2] = "gard"})
 table.insert(tbl, GetString(DAS_SE_GRAVE))
 table.insert(tbl2, {[1] = "grave"})
 
--- ...
--- now set the table with the quest names for the zone
 DAS.shareables[zoneId]      = tbl
--- call the func to make the bingo table.
 DAS.makeBingoTable(zoneId, tbl2)
---[[ you now have two maps:
-  --        {questName -> questId}
-  --        {bingoCode -> questId}
-  -- to save performance, the quest ID is stored in the control, on top of that there's a table somewhere in the DAS table that holds
-  -- the active quest IDs. There's a lot of redundancy in this AddOn, since I've dropped dead, feel free to optimize.
--- ]]
--- If there are subzones, you register them like this:
 DAS.subzones[1138] = 1133 -- Dragonhold
 DAS.subzones[1146] = 1133 -- Tideholm
 DAS.subzones[1134] = 1133 -- Forsaken Citadel
 DAS.subzones[1135] = 1133 -- Moonlite Cove
--- Quest lookup happens via
-local zoneId = DAS.GetZoneId()
-local quests = DAS.shareables[zoneId] or DAS.shareables[DAS.subzones[zoneId]] or {}
---[[
-  That way, if you're in a zone's subzone, it will show the zone's parent quests, unless
-  you feel like setting up extra tables for those that only show the current (delve) quest.
-  See Morrowind.lua for examples of that.
--- ]]
 -- set up auto quest accept:
 DAS.questStarter[zoneId] = {
   [GetString(DAS_QUEST_SE_BOSS)]    = true,  -- Senchal/WB/Bruccius Baenius
@@ -116,13 +90,6 @@ DAS.questFinisher[zoneId] = {
   [GetString(DAS_QUEST_SE_DRAGONS)]    = true,  -- Dragon island/Dragons
   [GetString(DAS_QUEST_SE_DELVE2)]    = true,  -- Dragon island/Delve relic
 }
---[[
-  I'm matching against the quest IDs for auto accepting quest shares.
-  Reason: Comparing numbers is a tonne cheaper than comparing strings.
-  Make sure you register the quest IDs. Unfortunately, you can only see them
-  when you get a quest shared OR via iteration after yu have completed those.
--- ]]
--- Set up like below (Morrowind example):
 DAS.questIds[zoneId] = {
   --Bruccius Baenius
   [6422] = true, --	A Rogue and His Rice	Бродяга и рис
@@ -150,23 +117,3 @@ DAS.questIds[zoneId] = {
   [6429] = true, --	Digging Up the Garden	Копание в саду
   [6406] = true, --	A Lonely Grave	Одинокая могила
 }
--- or by loop (Summerset example)
---[[DAS.questIds[zoneId] = {}
-for i=6082, 6087 do
-  DAS.questIds[zoneId][i] = true
-  DAS_QUEST_IDS[i] = true
-end
-]]
--- now hook up additiona subzone IDs (like Clockwork City - Brass Citadel has its own ID
---DAS.zoneHasAdditionalId(zoneId2, zoneId)
---[[
-  Don't forget to register the zone ID in the options. If the AddOn isn't detecting active in the settings
-  for its zone ID, it won't show.
-  ..\00_startup
-  defaults.tracked[zoneId]
-  You also need to register a menu setting so users can toggle it on and off
-  ..\DASMenu.lua
-  Hook up your new quest data file in the AddOn's manifest file:
-  ..\DailyAutoShare.txt
-  ... and you're good to go.
-]]


### PR DESCRIPTION
People have been copypasting TOO MUCH of your ExampleQuestData. There are two uncommented lines that were screwing up the questGiver tables in random places.

These files are pending further refactors later to bring them in line with how Morrowind/CC/Murkmire/... are structured.