### PR TITLE
DasSubList fixes

### DIFF
--- a/DASContextMenu.lua
+++ b/DASContextMenu.lua
@@ -48,8 +48,15 @@ local function toggleQuest()
     DAS.ToggleQuest(currentControl)
     DAS.RefreshLabelsWithDelay()
 end
-local function toggleSubList()
-    DasSubList:SetHidden(not DasSubList:IsHidden())
+local function toggleSubList(control)
+	local isHidden = DasSubList:IsHidden()
+	if (isHidden) then
+		DAS.SetSubLabels(control.dataQuestList)
+	end
+	DasSubList:SetHidden(not isHidden)
+	if (isHidden) then
+		DAS.setFontSize(DAS.sublabels)
+	end
 end
 function DAS.OnRightClick(control, verbose)
 	if nil == control then return end
@@ -63,9 +70,9 @@ function DAS.OnRightClick(control, verbose)
         SetMenuSpacing(3)
         SetMenuPad(10)
         SetMenuMinimumWidth(185)
-        if nil ~= control.dataQuestList then
+        if nil ~= control.dataQuestList and {} ~= control.dataQuestList then
             AddCustomMenuItem(GetString(DAS_TOGGLE_SUBLIST),
-				toggleSubList,
+				function() toggleSubList(control) end,
 				MENU_ADD_OPTION_LABEL
 			)
         else

--- a/DasGui.lua
+++ b/DasGui.lua
@@ -27,6 +27,7 @@ function DAS.RefreshControl(refreshQuestCache)
 	DasHandle:SetHidden(  stateIsHidden)
 	DasControl:SetHidden( stateIsHidden)
 	DasList:SetHidden(    stateIsMinimised or stateIsHidden)
+	DasSubList:SetHidden(true)
   DAS.RefreshLabelsWithDelay()
 end
 local function SetAlpha(control, value)
@@ -78,10 +79,14 @@ local function setButtonStates()
 end
 DAS.SetButtonStates = setButtonStates
 function DAS.QuestLabelClicked(control, mouseButton)
-  DAS.SetSubLabels(control.dataQuestList)
   if mouseButton == MOUSE_BUTTON_INDEX_RIGHT then -- and isValidJournalIndex then
 		return DAS.OnRightClick(control)
   end
+	if (nil ~= control.dataQuestList and {} ~= control.dataQuestList) then
+		DAS.SetSubLabels(control.dataQuestList)
+		DasSubList:SetHidden(false)
+		DAS.setFontSize(DAS.sublabels)
+	end
 	local journalIndex          = control.dataJournalIndex or 99
 	if IsValidQuestIndex(journalIndex) then
     if journalIndex ~= DAS.trackedIndex then
@@ -182,8 +187,7 @@ local function makeSubLabelTitle(str, zoneId, listIndex)
   return string.sub(str, 0, idx+3) .. "..."
 end
 function DAS.SetSubLabels(questTable)
-  DasSubList:SetHidden(nil == questTable or {} == questTable)
-  if DasSubList:IsHidden() then return end
+  if (nil == questTable or {} == questTable) then return end
   local status = DAS_STATUS_COMPLETE
   local index = 1
   for idx, questName in pairs(questTable) do
@@ -214,6 +218,7 @@ function DAS.SetSubLabels(questTable)
     label:SetText("")
     label:SetHidden(true)
   end
+  DasSubList:SetHeight(0)
   DAS.SetLabelFontSize()
   return status
 end


### PR DESCRIPTION
1. Hide SubList on zone changes to avoid showing any stale quests
2. SetHeight(0) on the SubList to auto-fit when the number of quests changes
3. Don't toggle the SubList on Right-click immediately
4. Fix the interactions when there are multiple SubList parents (e.g. Fighters & Mages)