### PR TITLE
Fix Dependencies

### DIFF
--- a/DailyAutoShare.txt
+++ b/DailyAutoShare.txt
@@ -3,8 +3,8 @@
 ## Version: 4.0
 ## APIVersion: 100035
 ## SavedVariables: DAS_Settings DAS_Globals
-## DependsOn: LibAddonMenu-2.0
-## OptionalDependsOn: pchat
+## DependsOn: LibAddonMenu-2.0 LibCustomMenu
+## OptionalDependsOn: pchat rChat
 
 libs\LibCustomTitles.lua
 


### PR DESCRIPTION
1. LibCustomMenu is used but not listed as a dependency, causing LUA errors if only LAM is installed
2. rChat is a fork of pChat, added to OptionalDependsOn to avoid loading DAS before it