### PR TITLE
Remember the guild invite settings

### DIFF
--- a/00_startup.lua
+++ b/00_startup.lua
@@ -306,6 +306,11 @@ local function OnPlayerActivated(eventCode)
 	DAS.SetHidden(not active)
   DAS.SetAutoInvite(DAS.GetAutoInvite()) -- disables if we aren't group lead
   DAS.SetChatListenerStatus(DAS.autoInviting)
+	DAS.SetListenInGuilds(DAS.GetSettings().listenInGuilds)
+	local guildInviteNumber = DAS.GetSettings().guildInviteNumber
+	if guildInviteNumber then
+		DAS.SetGuildInviteNumber(guildInviteNumber)
+	end
   DAS.guildInviteText = DAS.GetGuildInviteText()
   DAS.cacheChatterData()
 end


### PR DESCRIPTION
Currently they are not hooked up at the start-up and thus do not persist after reloads/relogs.