### PR TITLE
Restore QuestList deactivation and hiding

### DIFF
--- a/00_startup.lua
+++ b/00_startup.lua
@@ -103,10 +103,25 @@ local defaults = {
 			active = true,
     },
   },
+	-- Guilds
+	[57] = {
+		fg = {
+			invisible = false,
+			active = true,
+		},
+		mg = {
+			invisible = false,
+			active = true,
+		},
+		ud = {
+			invisible = false,
+			active = true,
+		},
+	},
   questShareString            = "I can give a DailyAutoShare for <<1>>, type <<2>> for an instant invite",
   whisperString               = "whisper + for an instant invite",
-	guildInviteText,
-	listenInGuilds,
+	guildInviteText = nil,
+	listenInGuilds = false,
   whisperOnly                 = false,
 	autoAcceptInvite 			      = false,
 	autoAcceptInviteInterval 	  = 5,

--- a/DasGui.lua
+++ b/DasGui.lua
@@ -123,7 +123,7 @@ function DAS.MinMaxButton()
 	DAS.RefreshControl()
 end
 local function shouldHideLabel(questName, zoneId)
-  local questLists = DAS.GetZoneQuests(zoneId) or {}
+	local questLists = DAS.QuestLists[zoneId] or {}
 	-- d(zo_strformat("should <<1>> be hidden?", questName))
 	for questListName, questListData in pairs(questLists) do
 		if questListData[questName] then
@@ -248,7 +248,7 @@ function DAS.setLabels(zoneQuests)
           label.dataQuestName     = questNameOrTable
           label.dataQuestState    = DAS.GetQuestStatus(label.dataQuestName)
         end
-        local hideLabel = (hideCompleted and label.dataQuestState == DAS_STATUS_COMPLETE) or shouldHideLabel(label.dataQuestName, zoneId)
+        local hideLabel = (DAS.GetHideCompleted() and label.dataQuestState == DAS_STATUS_COMPLETE) or shouldHideLabel(label.dataQuestName, zoneId)
         -- d(zo_strformat("DAS: <<1>> state <<2>>", label.dataQuestName, label.dataQuestState))
         label:SetHidden(hideLabel)
         label.dataJournalIndex 	= DAS.GetLogIndex(label.dataQuestName)

--- a/questData/GuildQuests.lua
+++ b/questData/GuildQuests.lua
@@ -34,8 +34,6 @@ DAS.subLists.fg = DAS.subLists.guilds
 DAS.subLists.mg = DAS.subLists.guilds
 DAS.subLists.ud = DAS.subLists.guilds
 
-DAS.QuestLists[zoneId2]  = DAS.QuestLists[zoneId]
-DAS.QuestLists[zoneId3]  = DAS.QuestLists[zoneId]
 DAS.QuestListTitles = DAS.QuestListTitles or {}
 DAS.QuestListTitles[zoneId] = {
 	[1] = GetString(DAS_GUILD_ANCHORS),
@@ -44,48 +42,52 @@ DAS.QuestListTitles[zoneId] = {
 DAS.QuestListTitles[zoneId2] = DAS.QuestListTitles[zoneId]
 DAS.QuestListTitles[zoneId3] = DAS.QuestListTitles[zoneId]
 local zoneIds = {
-    [104] = {["fg"] = GetString(DAS_FG_ALIKR), ["mg"] = GetString(DAS_MG_ALIKR), ["ud"] = GetString(DAS_UD_ALIKR)}, -- Alik'r Desert
-    [381] = {["fg"] = GetString(DAS_FG_AURID), ["mg"] = GetString(DAS_MG_AURID), ["ud"] = GetString(DAS_UD_AURID)}, -- Auridon
-    [92 ] = {["fg"] = GetString(DAS_FG_BANGK), ["mg"] = GetString(DAS_MG_BANGK), ["ud"] = GetString(DAS_UD_BANGK)}, -- Bangkorai
-    [57 ] = {["fg"] = GetString(DAS_FG_DESHA), ["mg"] = GetString(DAS_MG_DESHA), ["ud"] = GetString(DAS_UD_DESHA)}, -- Deshaan
-    [101] = {["fg"] = GetString(DAS_FG_EASTM), ["mg"] = GetString(DAS_MG_EASTM), ["ud"] = GetString(DAS_UD_EASTM)}, -- Eastmarch
-    [3  ] = {["fg"] = GetString(DAS_FG_GLENU), ["mg"] = GetString(DAS_MG_GLENU), ["ud"] = GetString(DAS_UD_GLENU)}, -- Glenumbra
-    [383] = {["fg"] = GetString(DAS_FG_GRAHT), ["mg"] = GetString(DAS_MG_GRAHT), ["ud"] = GetString(DAS_UD_GRAHT)}, -- Grahtwood
-    [108] = {["fg"] = GetString(DAS_FG_GREEN), ["mg"] = GetString(DAS_MG_GREEN), ["ud"] = GetString(DAS_UD_GREEN)}, -- Greenshade
-    [58 ] = {["fg"] = GetString(DAS_FG_MALAB), ["mg"] = GetString(DAS_MG_MALAB), ["ud"] = GetString(DAS_UD_MALAB)}, -- Malabal Tor
-    [382] = {["fg"] = GetString(DAS_FG_REAPE), ["mg"] = GetString(DAS_MG_REAPE), ["ud"] = GetString(DAS_UD_REAPE)}, -- Reaper's March
-    [103] = {["fg"] = GetString(DAS_FG_RIFT),  ["mg"] = GetString(DAS_MG_RIFT),  ["ud"] = GetString(DAS_UD_RIFT)},  -- The Rift
-    [20 ] = {["fg"] = GetString(DAS_FG_RIVEN), ["mg"] = GetString(DAS_MG_RIVEN), ["ud"] = GetString(DAS_UD_RIVEN)}, -- Rivenspire
-    [117] = {["fg"] = GetString(DAS_FG_SHADO), ["mg"] = GetString(DAS_MG_SHADO), ["ud"] = GetString(DAS_UD_SHADO)}, -- Shadowfen
-    [41 ] = {["fg"] = GetString(DAS_FG_STONE), ["mg"] = GetString(DAS_MG_STONE), ["ud"] = GetString(DAS_UD_STONE)}, -- Stonefalls
-    [19 ] = {["fg"] = GetString(DAS_FG_STORM), ["mg"] = GetString(DAS_MG_STORM), ["ud"] = GetString(DAS_UD_STORM)}, -- Stormhaven
+	[104] = {["fg"] = GetString(DAS_FG_ALIKR), ["mg"] = GetString(DAS_MG_ALIKR), ["ud"] = GetString(DAS_UD_ALIKR)}, -- Alik'r Desert
+	[381] = {["fg"] = GetString(DAS_FG_AURID), ["mg"] = GetString(DAS_MG_AURID), ["ud"] = GetString(DAS_UD_AURID)}, -- Auridon
+	[92 ] = {["fg"] = GetString(DAS_FG_BANGK), ["mg"] = GetString(DAS_MG_BANGK), ["ud"] = GetString(DAS_UD_BANGK)}, -- Bangkorai
+	[57 ] = {["fg"] = GetString(DAS_FG_DESHA), ["mg"] = GetString(DAS_MG_DESHA), ["ud"] = GetString(DAS_UD_DESHA)}, -- Deshaan
+	[101] = {["fg"] = GetString(DAS_FG_EASTM), ["mg"] = GetString(DAS_MG_EASTM), ["ud"] = GetString(DAS_UD_EASTM)}, -- Eastmarch
+	[3  ] = {["fg"] = GetString(DAS_FG_GLENU), ["mg"] = GetString(DAS_MG_GLENU), ["ud"] = GetString(DAS_UD_GLENU)}, -- Glenumbra
+	[383] = {["fg"] = GetString(DAS_FG_GRAHT), ["mg"] = GetString(DAS_MG_GRAHT), ["ud"] = GetString(DAS_UD_GRAHT)}, -- Grahtwood
+	[108] = {["fg"] = GetString(DAS_FG_GREEN), ["mg"] = GetString(DAS_MG_GREEN), ["ud"] = GetString(DAS_UD_GREEN)}, -- Greenshade
+	[58 ] = {["fg"] = GetString(DAS_FG_MALAB), ["mg"] = GetString(DAS_MG_MALAB), ["ud"] = GetString(DAS_UD_MALAB)}, -- Malabal Tor
+	[382] = {["fg"] = GetString(DAS_FG_REAPE), ["mg"] = GetString(DAS_MG_REAPE), ["ud"] = GetString(DAS_UD_REAPE)}, -- Reaper's March
+	[103] = {["fg"] = GetString(DAS_FG_RIFT),  ["mg"] = GetString(DAS_MG_RIFT),  ["ud"] = GetString(DAS_UD_RIFT)},  -- The Rift
+	[20 ] = {["fg"] = GetString(DAS_FG_RIVEN), ["mg"] = GetString(DAS_MG_RIVEN), ["ud"] = GetString(DAS_UD_RIVEN)}, -- Rivenspire
+	[117] = {["fg"] = GetString(DAS_FG_SHADO), ["mg"] = GetString(DAS_MG_SHADO), ["ud"] = GetString(DAS_UD_SHADO)}, -- Shadowfen
+	[41 ] = {["fg"] = GetString(DAS_FG_STONE), ["mg"] = GetString(DAS_MG_STONE), ["ud"] = GetString(DAS_UD_STONE)}, -- Stonefalls
+	[19 ] = {["fg"] = GetString(DAS_FG_STORM), ["mg"] = GetString(DAS_MG_STORM), ["ud"] = GetString(DAS_UD_STORM)}, -- Stormhaven
 }
+
+local tbl_fg, tbl_mg, tbl_ud = {}, {}, {}
 for id, guildStrings in pairs(zoneIds) do
-    DAS.shareables[id]      = DAS.shareables[id]    or {}
-    DAS.QuestLists[id]      = DAS.QuestLists[id]    or {}
-    DAS.QuestLists[id].fg   = DAS.QuestLists[id].fg or {}
-    DAS.QuestLists[id].mg   = DAS.QuestLists[id].mg or {}
-    DAS.QuestLists[id].ud   = DAS.QuestLists[id].ud or {}
-    -- local bingoTable        = DAS.bingo[id]         or {}
-    table.insert(DAS.shareables[id],    guildStrings.fg)
-    -- table.insert(bingoTable,            fgBingo)
-    table.insert(DAS.shareables[id],    guildStrings.mg)
-    -- table.insert(bingoTable,            mgBingo)
-    table.insert(DAS.shareables[id],    guildStrings.ud)
-    -- table.insert(bingoTable,            udBingo)
-    -- DAS.makeBingoTable(id,              bingoTable)
-    table.insert(DAS.QuestLists[zoneId].fg, guildStrings.fg)
-    table.insert(DAS.QuestLists[zoneId].mg, guildStrings.mg)
-    table.insert(DAS.QuestLists[zoneId].ud, guildStrings.ud)
+	DAS.shareables[id] = DAS.shareables[id] or {}
+	local bingoTable        = DAS.bingo[id]         or {}
+	table.insert(DAS.shareables[id],    guildStrings.fg)
+	table.insert(bingoTable,            fgBingo)
+	table.insert(DAS.shareables[id],    guildStrings.mg)
+	table.insert(bingoTable,            mgBingo)
+	table.insert(DAS.shareables[id],    guildStrings.ud)
+	table.insert(bingoTable,            udBingo)
+	DAS.makeBingoTable(id,              bingoTable)
+	DAS.QuestLists[zoneId].fg[guildStrings.fg] = true
+	DAS.QuestLists[zoneId].mg[guildStrings.mg] = true
+	DAS.QuestLists[zoneId].ud[guildStrings.ud] = true
+	table.insert(tbl_fg, guildStrings.fg)
+	table.insert(tbl_mg, guildStrings.mg)
+	table.insert(tbl_ud, guildStrings.ud)
 end
+DAS.QuestLists[zoneId2] = DAS.QuestLists[zoneId]
+DAS.QuestLists[zoneId3] = DAS.QuestLists[zoneId]
 
-table.insert(tbl1, DAS.QuestLists[zoneId].fg)
--- table.insert(tbl2, fgBingo)
-table.insert(tbl1, DAS.QuestLists[zoneId].mg)
--- table.insert(tbl2, mgBingo)
+table.insert(tbl1, tbl_fg)
+table.insert(tbl2, fgBingo)
+table.insert(tbl1, tbl_mg)
+table.insert(tbl2, mgBingo)
 
-for idx, questName in pairs(DAS.QuestLists[zoneId].ud) do
+for _, questName in pairs(tbl_ud) do
     table.insert(tbl1, questName)
+    -- cannot assign the same bingo code to multiple quests like that
     -- table.insert(tbl2, udBingo)
 end
 

--- a/questData/Morrowind.lua
+++ b/questData/Morrowind.lua
@@ -8,45 +8,53 @@ local tbl2 = {}
 DAS.QuestLists = DAS.QuestLists or {}
 DAS.QuestLists[zoneId] = {
 	["relic"] = {
-		[1] = GetString(DAS_M_REL_ASHAL),
-		[2] = GetString(DAS_M_REL_ASSAR),
-		[3] = GetString(DAS_M_REL_ASHUR),
-		[4] = GetString(DAS_M_REL_DUSHA),
-		[5] = GetString(DAS_M_REL_EBERN),
-		[6] = GetString(DAS_M_REL_MAELK),
-		[7] = GetString(DAS_M_REL_YASAM),
-  },
+		[GetString(DAS_M_REL_ASHAL)] = true,
+		[GetString(DAS_M_REL_ASSAR)] = true,
+		[GetString(DAS_M_REL_ASHUR)] = true,
+		[GetString(DAS_M_REL_DUSHA)] = true,
+		[GetString(DAS_M_REL_EBERN)] = true,
+		[GetString(DAS_M_REL_MAELK)] = true,
+		[GetString(DAS_M_REL_YASAM)] = true,
+	},
 	["hunt"] = {
-		[1] = GetString(DAS_M_HUNT_EATER),
-		[2] = GetString(DAS_M_HUNT_ZEXXI),
-		[3] = GetString(DAS_M_HUNT_RAZOR),
-		[4] = GetString(DAS_M_HUNT_JAGGE),
-		[5] = GetString(DAS_M_HUNT_STOMP),
-		[6] = GetString(DAS_M_HUNT_TARRA),
-		[7] = GetString(DAS_M_HUNT_SVEET),
-  },
+		[GetString(DAS_M_HUNT_EATER)] = true,
+		[GetString(DAS_M_HUNT_ZEXXI)] = true,
+		[GetString(DAS_M_HUNT_RAZOR)] = true,
+		[GetString(DAS_M_HUNT_JAGGE)] = true,
+		[GetString(DAS_M_HUNT_STOMP)] = true,
+		[GetString(DAS_M_HUNT_TARRA)] = true,
+		[GetString(DAS_M_HUNT_SVEET)] = true,
+	},
 	["delve"] = {
-		[1] = GetString(DAS_M_DELVE_DAEDR),
-		[2] = GetString(DAS_M_DELVE_KWAMA),
-		[3] = GetString(DAS_M_DELVE_MISIN),
-		[4] = GetString(DAS_M_DELVE_TAXES),
-		[5] = GetString(DAS_M_DELVE_TRIBA),
-		[6] = GetString(DAS_M_DELVE_SYNDI),
-  },
+		[GetString(DAS_M_DELVE_DAEDR)] = true,
+		[GetString(DAS_M_DELVE_KWAMA)] = true,
+		[GetString(DAS_M_DELVE_MISIN)] = true,
+		[GetString(DAS_M_DELVE_TAXES)] = true,
+		[GetString(DAS_M_DELVE_TRIBA)] = true,
+		[GetString(DAS_M_DELVE_SYNDI)] = true,
+	},
 	["boss"] = {
-		[1] = GetString(DAS_M_BOSS_WUYWU),
-		[2] = GetString(DAS_M_BOSS_SWARM),
-		[3] = GetString(DAS_M_BOSS_NILTH),
-		[4] = GetString(DAS_M_BOSS_SALOT),
-		[5] = GetString(DAS_M_BOSS_SIREN),
-		[6] = GetString(DAS_M_BOSS_APPRE),
-  },
+		[GetString(DAS_M_BOSS_WUYWU)] = true,
+		[GetString(DAS_M_BOSS_SWARM)] = true,
+		[GetString(DAS_M_BOSS_NILTH)] = true,
+		[GetString(DAS_M_BOSS_SALOT)] = true,
+		[GetString(DAS_M_BOSS_SIREN)] = true,
+		[GetString(DAS_M_BOSS_APPRE)] = true,
+	},
 }
 DAS.QuestListTitles = DAS.QuestListTitles or {}
 DAS.QuestListTitles[zoneId] = {
 	[1] = GetString(DAS_LIST_M_RELIC),
 }
-table.insert(tbl, DAS.QuestLists[zoneId].relic)
+table.insert(tbl, {
+	GetString(DAS_M_REL_ASHAL),
+	GetString(DAS_M_REL_ASSAR),
+	GetString(DAS_M_REL_ASHUR),
+	GetString(DAS_M_REL_DUSHA),
+	GetString(DAS_M_REL_EBERN),
+	GetString(DAS_M_REL_MAELK),
+	GetString(DAS_M_REL_YASAM),
+})
 table.insert(tbl2, "relic")
 table.insert(tbl, GetString(DAS_M_HUNT_EATER))
 table.insert(tbl2, "ash")

--- a/questData/Murkmire.lua
+++ b/questData/Murkmire.lua
@@ -3,28 +3,28 @@ local tbl = {}
 local tbl2 = {}
 DAS.QuestLists[zoneId] = {
 	["root"] = {
-		[1] = GetString(DAS_SLAVES_ROOT_1),
-		[2] = GetString(DAS_SLAVES_ROOT_2),
-		[3] = GetString(DAS_SLAVES_ROOT_3),
-		[4] = GetString(DAS_SLAVES_ROOT_4),
-		[5] = GetString(DAS_SLAVES_ROOT_5),
-  },
+		[GetString(DAS_SLAVES_ROOT_1)] = true,
+		[GetString(DAS_SLAVES_ROOT_2)] = true,
+		[GetString(DAS_SLAVES_ROOT_3)] = true,
+		[GetString(DAS_SLAVES_ROOT_4)] = true,
+		[GetString(DAS_SLAVES_ROOT_5)] = true,
+	},
 	["delve"] = {
-		[1] = GetString(DAS_SLAVES_DELVE_1),
-		[2] = GetString(DAS_SLAVES_DELVE_2),
-		[3] = GetString(DAS_SLAVES_DELVE_3),
-		[4] = GetString(DAS_SLAVES_DELVE_4),
-		[5] = GetString(DAS_SLAVES_DELVE_5),
-		[6] = GetString(DAS_SLAVES_DELVE_6),
-  },
+		[GetString(DAS_SLAVES_DELVE_1)] = true,
+		[GetString(DAS_SLAVES_DELVE_2)] = true,
+		[GetString(DAS_SLAVES_DELVE_3)] = true,
+		[GetString(DAS_SLAVES_DELVE_4)] = true,
+		[GetString(DAS_SLAVES_DELVE_5)] = true,
+		[GetString(DAS_SLAVES_DELVE_6)] = true,
+	},
 	["boss"] = {
-		[1] = GetString(DAS_SLAVES_BOSS_1),
-		[2] = GetString(DAS_SLAVES_BOSS_2),
-		[3] = GetString(DAS_SLAVES_BOSS_3),
-		[4] = GetString(DAS_SLAVES_BOSS_4),
-		[5] = GetString(DAS_SLAVES_BOSS_5),
-		[5] = GetString(DAS_SLAVES_BOSS_6),
-  },
+		[GetString(DAS_SLAVES_BOSS_1)] = true,
+		[GetString(DAS_SLAVES_BOSS_2)] = true,
+		[GetString(DAS_SLAVES_BOSS_3)] = true,
+		[GetString(DAS_SLAVES_BOSS_4)] = true,
+		[GetString(DAS_SLAVES_BOSS_5)] = true,
+		[GetString(DAS_SLAVES_BOSS_6)] = true,
+	},
 }
 -- Grave Circumstances
 table.insert(tbl, GetString(DAS_SLAVES_BOSS_1))


### PR DESCRIPTION
The ability to deactivate and/or hide QuestLists got broken somewhere between 3.1.5 and 3.7. The current code makes little sense and runs checks that cannot succeed. The tables were supposed to be string sets, but were converted into arrays for whatever reason.

This commit also restores some functionality of bingo codes for the guild quests.