### PR TITLE
Rework the DAS Settings Panel Layout

### DIFF
--- a/DASMenu.lua
+++ b/DASMenu.lua
@@ -1,647 +1,696 @@
 local DAS = DailyAutoShare
-local optionsData
-local questShareDefault
-local GetSettings = DAS.GetSettings
 local LAM = LibAddonMenu2 or LibStub:GetLibrary("LibAddonMenu-2.0")
+if not LAM then return end
 
 function DAS.CreateMenu(savedVars, defaults)
-  uestShareDefault = defaults.questShareString
-	local panelData = 	{
-					type            = "panel",
-					name            = DAS.name,
-					displayname     = name,
-					author          = DAS.author,
-					version         = DAS.version,
-					slashCommand    = "/das_menu",
-				}
-	LAM:RegisterAddonPanel("DailyAutoShare_OptionsPanel", panelData)
-	optionsData =	{ -- optionsData
-				{ -- Use global configuration?
-					type    = "checkbox",
-					name    = "Turn on debugging?",
-					getFunc = function() return DAS.GetDebugMode() end,
-					setFunc = function(value) DAS.SetDebugMode(value) end
-				},
-				{ -- header: Use global variables?
-					type    = "header",
-					name    = "Use global variables?"
-				},
-				{ -- Use global configuration?
-					type    = "checkbox",
-					tooltip = "Use the same settings for all characters?",
-					name    = "Use global configuration?",
-		      			width   = "half",
-					getFunc = function() return DAS.GetUseGlobalSettings() end,
-					setFunc = function(value) DAS.SetUseGlobalSettings(value) end
-    				},
-    				{ -- checkbox: Hide UI window
-					type    = "checkbox",
-					name    = "Hide UI window",
-					width   = "half",
-					getFunc = function() return DAS.GetHidden() end,
-					setFunc = function(value) DAS.SetHidden(value) end
-    				},
-				{ -- header: be elaborate?
-					type    = "header",
-					name    = "Throttle"
-				},
-				{ -- slider: group invite delay
-					type 	= "slider",
-					name 	= "Group invite delay (in ms)",
-					tooltip = ("adjust this if you encounter disconnects when trying to create a group.\n1000 ms are one second.") ,
-					min 	= 250,
-					step	= 10,
-					max 	= 2500,
-					getFunc = function() return DAS.GetGroupInviteDelay() end,
-					setFunc = function(value) DAS.SetGroupInviteDelay(value) end
-			    	},
-				{ -- slider: group invite delay
-					type 	= "slider",
-					name 	= "Quest share delay (in ms)",
-					tooltip = ("adjust this if you encounter disconnects when new group members join.\n1000 ms are one second.") ,
-					min 	= 250,
-					step	= 10,
-					max 	= 2500,
-					getFunc = function() return DAS.GetQuestShareDelay() end,
-					setFunc = function(value) DAS.SetQuestShareDelay(value) end
-    				},
-				{
-					type    = "description",
-					title   = "Activate auto quest stuff in...",
-					text    = GetString(DAS_MENU_ACTIV_EXPLAIN),
-				},
-				{ -- header: activate add-on in...
-					type    = "submenu",
-					name    = "Activate",
-					controls = 
-					{
-						{-- Elsweyr
-							type    = "header",
-							title  	= "zones",
-						},
-						{ -- checkbox: Elsweyr
-							type    = "checkbox",
-							tooltip = "Elsweyr?",
-							name    = "Activate in Elsweyr?",
-							getFunc = function() return DAS.GetActiveIn(1086) end,
-							setFunc = function(value) DAS.SetActiveIn(1086, value) end
-						},
-						{ -- checkbox: Southern Elsweyr
-							type    = "checkbox",
-							tooltip = "Southern Elsweyr?",
-							name    = "Activate in Southern Elsweyr?",
-							getFunc = function() return DAS.GetActiveIn(1133) end,
-							setFunc = function(value) DAS.SetActiveIn(1133, value) end
-						},
-						{ -- checkbox: Murkmire
-							type    = "checkbox",
-							tooltip = "Murkmire?",
-							name    = "Activate in Murkmire?",
-							getFunc = function() return DAS.GetActiveIn(726) end,
-							setFunc = function(value) DAS.SetActiveIn(726, value) end
-						},
-						{ -- checkbox: Summerset
-							type    = "checkbox",
-							tooltip = "Summerset?",
-							name    = "Activate in Summerset?",
-							getFunc = function() return DAS.GetActiveIn(1011) end,
-							setFunc = function(value) DAS.SetActiveIn(1011, value) end
-        					},
-						{ -- checkbox: Clockwork City?
-							  type    = "checkbox",
-							  tooltip = "activate",
-							  name    = "Activate in Clockwork City?",
-							  getFunc = function() return DAS.GetActiveIn(980) end,
-							  setFunc = function(value)
-							    DAS.SetActiveIn(980, value)
-							    DAS.SetActiveIn(981, value)
-							    DAS.SetActiveIn(983, value)
-							  end
-        					},
-						{ -- checkbox: Morrowind
-							type    = "checkbox",
-							tooltip = "Vvardenfell?",
-							name    = "Activate in Vvardenfell?",
-							getFunc = function() return DAS.GetActiveIn(849) end,
-							setFunc = function(value) DAS.SetActiveIn(849, value) end
-						},
-						{ -- checkbox: Wrothgar
-							type    = "checkbox",
-							tooltip = "Wrothgar?",
-							name    = "Activate in Wrothgar?",
-							getFunc = function() return DAS.GetActiveIn(684) end,
-							setFunc = function(value) DAS.SetActiveIn(684, value) end
-						},
-						{ -- checkbox: The Gold Coast
-							type    = "checkbox",
-							tooltip = "The Gold Coast?",
-							name    = "Activate in The Gold Coast?",
-							getFunc = function() return DAS.GetActiveIn(823) end,
-							setFunc = function(value) DAS.SetActiveIn(823, value) end
-						},
-						{ -- checkbox: Blackwood
-							type    = "checkbox",
-							tooltip = "Blackwood?",
-							name    = "Activate in Blackwood?",
-							getFunc = function() return DAS.GetActiveIn(1261) end,
-							setFunc = function(value) DAS.SetActiveIn(1261, value) end
-						},
-						{ -- checkbox: Craglorn
-							type    = "checkbox",
-							tooltip = "Craglorn?",
-							name    = "Activate in Craglorn?",
-							getFunc = function() return DAS.GetActiveIn(888) end,
-							setFunc = function(value) DAS.SetActiveIn(888, value) end
-						},
-						{ -- checkbox: Cyro
-							type    = "checkbox",
-							tooltip = "Auto-accept and -turnin",
-							name    = "Cyrodiil",
-							getFunc = function() return DAS.GetActiveIn(181) end,
-							setFunc = function(value) DAS.SetActiveIn(181, value) end
-        					},
-						{ -- Separator: Advanced settings
-							type    = "submenu",
-							name    = "Advanced Settings",
-							controls    = 	
-							{
-								{ -- submenu: Murkmire
-									type        = "submenu",
-									name        = "Murkmire",
-									controls    = 	
-									{
-										{ -- header: Boss dailies
-											type    = "header",
-											name    = "Murkmire: Boss dailies"
-										},
-										{ -- checkbox: boss
-											type    = "checkbox",
-											tooltip = "Go boss hunting for Bolu?",
-											name    = "Enable?",
-											getFunc = function() return DAS.GetQuestListItem(726, "boss", "active") end,
-											setFunc = function(value)   DAS.SetQuestListItem(726, "boss", "active", value) end
-										},
-										{ -- checkbox: boss (hide)
-											type    = "checkbox",
-											name    = "Hide",
-											tooltip = "Don't show boss dailies on UI list \nKeeps sharing on group invite",
-											getFunc = function() return DAS.GetQuestListItem(726, "boss", "invisible") end,
-											setFunc = function(value) DAS.SetQuestListItem(726,   "boss", "invisible", value) end
-										},
-										{ -- header: Murkmire - Delves
-											type    = "header",
-											name    = "Murkmire: Delves"
-										},
-										{ -- checkbox: Murkmire - Delves
-											type    = "checkbox",
-											name    = "Enable?",
-											tooltip = "Delve dailies for Varo Hosidias",
-											getFunc = function() return DAS.GetQuestListItem(726, "delve", "active") end,
-											setFunc = function(value) DAS.SetQuestListItem(726,   "delve", "active", value) end
-										},
-										{ -- checkbox: Murkmire - Delves
-											type    = "checkbox",
-											name    = "Hide",
-											tooltip = "Don't show Ashlander hunt dailies on UI list",
-											getFunc = function() return DAS.GetQuestListItem(726, "delve", "invisible") end,
-											setFunc = function(value) DAS.SetQuestListItem(726,   "delve", "invisible", value) end
-										},
-										{ -- header: Root Whisper
-											type    = "header",
-											name    = "Root Whisper"
-										},
-										{ -- checkbox: Root Whisper
-											type    = "checkbox",
-											name    = "Enable?",
-											tooltip = "Enable Root Whisper dailies?",
-											getFunc = function() return DAS.GetQuestListItem(726, "root", "active") end,
-											setFunc = function(value) DAS.SetQuestListItem(726,   "root", "active", value) end
-										},
-										{ -- checkbox: Root Whisper
-											type    = "checkbox",
-											name    = "Hide?",
-											tooltip = "Don't show Root Whisper dailies on UI list",
-											getFunc = function() return DAS.GetQuestListItem(726, "root", "invisible") end,
-											setFunc = function(value) DAS.SetQuestListItem(726,   "root", "invisible", value) end
-										},
-									},
-								},-- end of submenu murkmire
-
-								{ -- submenu: Clockwork City
-									type    = "submenu",
-									name    = "Clockwork City",
-									controls = 
-									{
-										{ -- header: CC Worldbosses
-											type    = "header",
-											name    = "Worldbosses"
-										},
-										{ -- checkbox: relic
-											type    = "checkbox",
-											tooltip = "Enable world boss dailies",
-											name    = "Enable?",
-											getFunc = function() return DAS.GetQuestListItem(980, "boss", "active") end,
-											setFunc = function(value) DAS.SetQuestListItem(980, "boss", "active", value) end
-										},
-										{ -- checkbox: relic
-											type    = "checkbox",
-											name    = "Hide",
-											tooltip = "Don't show world boss dailies on UI list \nKeeps sharing on group invite",
-											getFunc = function() return DAS.GetQuestListItem(980, "boss", "invisible") end,
-											setFunc = function(value) DAS.SetQuestListItem(980, "boss", "invisible", value) end
-										},
-										{ -- header: CC Slagtown gathering dailies
-											type    = "header",
-											name    = "Slagtown: Gathering dailies"
-										},
-										{ -- checkbox: Slagtown gathering dailies
-											type    = "checkbox",
-											name    = "Enable?",
-											tooltip = "Slagtown gathering dailies?",
-											getFunc = function() return DAS.GetQuestListItem(980, "craft", "active") end,
-											setFunc = function(value) DAS.SetQuestListItem(980, "craft", "active", value) end
-										},
-										{ -- checkbox: Hide Slagtown gathering dailies
-											type    = "checkbox",
-											name    = "Hide",
-											tooltip = "Don't show Slagtown gathering dailies on UI list",
-											getFunc = function() return DAS.GetQuestListItem(980, "craft", "invisible") end,
-											setFunc = function(value) DAS.SetQuestListItem(980, "craft", "invisible", value) end
-										},
-										{ -- header: CC: Delves
-											type    = "header",
-											name    = "Clockwork City: Delves"
-										},
-										{ -- checkbox: delve
-											type    = "checkbox",
-											name    = "Enable?",
-											tooltip = "Clockwork City delve dailies?",
-											getFunc = function() return DAS.GetQuestListItem(980, "delve", "active") end,
-											setFunc = function(value) DAS.SetQuestListItem(980, "delve", "active", value) end
-										},
-										{ -- checkbox: Clockwork City: Delves
-											type    = "checkbox",
-											name    = "Hide?",
-											tooltip = "Don't show Clockwork City delve dailies on UI list",
-											getFunc = function() return DAS.GetQuestListItem(980, "delve", "invisible") end,
-											setFunc = function(value) DAS.SetQuestListItem(980, "delve", "invisible", value) end
-										},
-										{ -- header: Vivec: Delves
-											type    = "header",
-											name    = "Clockwork City: Crow"
-										},
-										{ -- checkbox: Clockwork City crow
-											type    = "checkbox",
-											name    = "Enable?",
-											tooltip = "Enable Clockwork City crow dailies?",
-											getFunc = function() return DAS.GetQuestListItem(980, "crow", "active") end,
-											setFunc = function(value) DAS.SetQuestListItem(980, "crow", "active", value) end
-										},
-										{ -- checkbox: Clockwork City crow hide
-											type    = "checkbox",
-											name    = "Hide?",
-											tooltip = "Don't show Clockwork City crow dailies on UI list",
-											getFunc = function() return DAS.GetQuestListItem(980, "crow", "invisible") end,
-											setFunc = function(value) DAS.SetQuestListItem(980, "crow", "invisible", value) end
-										},
-									},
-								}, -- end of submenu : Clockwork City
-
-								{ -- submenu: Morrowind
-									type        = "submenu",
-									name        = "Vvardenfell",
-									controls    = 
-									{
-										{ -- header: Ashlander: Relics
-											type    = "header",
-											name    = "Ashlander: Relics"
-										},
-										{ -- checkbox: relic
-											type    = "checkbox",
-											tooltip = "Go relic hunting for the Urshilaku?",
-											name    = "Enable?",
-											getFunc = function() return DAS.GetQuestListItem(849, "relic", "active") end,
-											setFunc = function(value) DAS.SetQuestListItem(849, "relic", "active", value) end
-										},
-										{ -- checkbox: relic
-											type    = "checkbox",
-											name    = "Hide",
-											tooltip = "Don't show Ashlander relic dailies on UI list \nKeeps sharing on group invite",
-											getFunc = function() return DAS.GetQuestListItem(849, "relic", "invisible")end,
-											setFunc = function(value) DAS.SetQuestListItem(849, "relic", "invisible", value) end
-										},
-										{ -- header: Ashlander: Hunt
-											type    = "header",
-											name    = "Ashlander: Hunt"
-										},
-										{ -- checkbox: Wrothgar
-											type    = "checkbox",
-											name    = "Enable?",
-											tooltip = "Ashlander hunt dailies?",
-											getFunc = function() return DAS.GetQuestListItem(849, "hunt", "active") end,
-											setFunc = function(value) DAS.SetQuestListItem(849, "hunt", "active", value) end
-										},
-										{ -- checkbox: Wrothgar
-											type    = "checkbox",
-											name    = "Hide",
-											tooltip = "Don't show Ashlander hunt dailies on UI list",
-											getFunc = function() return DAS.GetQuestListItem(849, "hunt", "invisible") end,
-											setFunc = function(value) DAS.SetQuestListItem(849, "hunt", "invisible", value) end
-										},
-										{ -- header: Vivec: Delves
-											type    = "header",
-											name    = "Vivec: Delves"
-										},
-										{ -- checkbox: Wrothgar
-											type    = "checkbox",
-											name    = "Enable?",
-											tooltip = "Hall of Justice delve dailies?",
-											getFunc = function() return DAS.GetQuestListItem(849, "delve", "active") end,
-											setFunc = function(value) DAS.SetQuestListItem(849, "delve", "active", value) end
-										},
-										{ -- checkbox: Vivec: Delves
-											type    = "checkbox",
-											name    = "Hide?",
-											tooltip = "Don't show Hall of Justice delve dailies on UI list",
-											getFunc = function() return DAS.GetQuestListItem(849, "delve", "invisible") end,
-											setFunc = function(value) DAS.SetQuestListItem(849, "delve", "invisible", value) end
-										},
-										{ -- header: Vivec: Delves
-											type    = "header",
-											name    = "Vivec: Worldbosses"
-										},
-										{ -- checkbox: Wrothgar
-											type    = "checkbox",
-											name    = "Enable?",
-											tooltip = "Enable Hall of Justice boss dailies?",
-											getFunc = function() return DAS.GetQuestListItem(849, "boss", "active") end,
-											setFunc = function(value) DAS.SetQuestListItem(849, "boss", "active", value) end
-										},
-										{ -- checkbox: Wrothgar
-											type    = "checkbox",
-											name    = "Hide?",
-											tooltip = "Don't show Hall of Justice boss dailies on UI list",
-											getFunc = function() return DAS.GetQuestListItem(849, "boss", "invisible") end,
-											setFunc = function(value) DAS.SetQuestListItem(849, "boss", "invisible", value) end
-										},
-									},
-								}, -- end of submenu : Morrowind
-
-								{ -- Submenu : Guild Dailies
-									type        = "submenu",
-									name        = "Guild dailies",
-									controls    = 
-									{
-										{ -- checkbox: Fighters Guild dailies?
-											type    = "checkbox",
-											tooltip = "Fighters/Mages Guild and Undaunted dailies? This is work in progress.",
-											name    = "Guild quests?",
-											getFunc = function() return DAS.GetActiveIn("guilds") end,
-											setFunc = function(value) DAS.SetActiveFor("guilds", value) end
-										},
-										{ -- checkbox: Fighters' Guild
-											type    = "checkbox",
-											tooltip = "Enable Fighters' Guild dailies",
-											name    = "Fighters' Guild",
-											getFunc = function() return DAS.GetActiveIn("fg") end,
-											setFunc = function(value) DAS.SetActiveFor("fg", value) end
-										},
-										{ -- checkbox: Mages' Guild
-											type    = "checkbox",
-										      tooltip = "Enable Mages' Guild dailies",
-										      name    = "Mages Guild",
-										      getFunc = function() return DAS.GetActiveIn("mg") end,
-										      setFunc = function(value) DAS.SetActiveFor("mg", value) end
-										},
-										{ -- checkbox: Undaunted
-										      type    = "checkbox",
-										      tooltip = "Enable Undaunted dailies",
-										      name    = "Undaunted",
-										      getFunc = function() return DAS.GetActiveIn("ud") end,
-										      setFunc = function(value) DAS.SetActiveFor("ud", value) end
-										},
-									},
-								}, -- end of submenu : Guild Dailies
-								{ -- submenu : Festivals
-									type        = "submenu",
-									name        = "Festivals",
-									controls = 
-									{
-										{ -- checkbox: relic
-											type    = "checkbox",
-											name    = "New Life",
-											tooltip = "Enable New Life festival",
-											getFunc = function() return DAS.GetActiveIn(101) end,
-											setFunc = function(value) DAS.SetActiveFor("newLife", value) end
-										},
-									},
-								},  -- end of submenu : Festivals
-							} 
-						},
-						
-      					}, -- End of "activate" menu
-    				},
-				{ -- checkbox: Hide UI window
-					type    = "checkbox",
-					name    = "Use whisper only",
-		      			tooltip = "This will ignore bingo spam in zone chat!",
-					getFunc = function() return DAS.GetWhisperOnly() end,
-					setFunc = function(value) GetSettings().whisperOnly = value end
-				},
-				{ -- header: Use global variables?
-					type    = "header",
-					name    = "User UI settings"
-    				},
-				{ -- submenu: User UI settings
-					type        = "submenu",
-					name        = "Look and feel and behavior",
-					controls    = 
-					{
-						{ -- checkbox: Lock UI window
-							type    = "checkbox",
-							name    = "Show Map markers?",
-							getFunc = function() return DAS.GetMarkerVisibility() end,
-							setFunc = function(value) DAS.SetMarkerVisibility(value) end
-						},
-						{   -- editbox: Quest share text
-							  type        = "editbox",
-							  isExtraWide = true,
-							  name        = "Quest share text",
-							  tooltip     = ("Text to generate when you spam quest shares.\n"
-							    .. "<<1>> will be replaced with the quest names, <<2>> with the bingo codes.\n"
-							  .. "Omit either to remove parameter. Include neither and sound like a fool."),
-							  getFunc     = function() return DAS.GetSettings().questShareString end,
-							  setFunc     = function(value) DAS.GetSettings().questShareString = value end,
-						},
-						{   -- editbox: Quest share text
-							  type        = "editbox",
-							  isExtraWide = true,
-							  name        = "Whisper only text",
-							  disabled    = not DAS.GetWhisperOnly(),
-							  tooltip     = "Will replace everything after <<1>>, in the string above",
-							  getFunc     = function() return DAS.GetSettings().whisperString end,
-							  setFunc     = function(value) DAS.GetSettings().whisperString = value end,
-						},
-						{   -- editbox: Quest share text
-							  type    = "button",
-							  name    = "Reset",
-							  tooltip = "Reset quest share text to default value",
-							  getFunc = function() return questShareDefault end,
-							  setFunc = function(value) DAS.GetSettings().questShareString = questShareDefault end,
-							  reference = "qsButton",
-						},
-						{ -- checkbox: Lock UI window
-							type    = "checkbox",
-							name    = "Lock UI window",
-							getFunc = function() return DAS.GetLocked() end,
-							setFunc = function(value) DAS.SetLocked(value) end
-						},
-						{ -- checkbox: Tooltip position
-							type    = "checkbox",
-							name    = "Tooltip to the right?",
-							tooltip = "Check this box to display the tooltip on the left side of the window",
-							getFunc = function() return DAS.GetSettings().tooltipRight end,
-							setFunc = function(value) DAS.GetSettings().tooltipRight = value end
-						},
-						{ -- checkbox: Reposition DropDown
-							type    = "checkbox",
-							name    = "DropUp instead of DropDown?",
-							tooltip = "Check this if you want the questList to appear above the drag bar instead of below",
-							getFunc = function() return DAS.GetUpsideDown() end,
-							setFunc = function(value) DAS.SetUpsideDown(value) end
-						},
-						{ -- checkbox: Start up minimized?
-							type    = "checkbox",
-							name    = "Start up minimized?",
-							tooltip = "Always minimize AddOn on first startup",
-							getFunc = function() return DAS.GetSettings().startupMinimized end,
-							setFunc = function(value) DAS.GetSettings().startupMinimized = value end
-						},
-						{ -- checkbox: AutoHide
-							type    = "checkbox",
-							name    = "Auto-hide when no open daily present?",
-							tooltip = "Check this if you want the DASWindow to be hidden when you're done",
-							getFunc = function() return DAS.GetAutoHide() end,
-							setFunc = function(value) DAS.SetAutoHide(value) end
-						},
-						{ -- checkbox: AutoMinimize
-							type    = "checkbox",
-							name    = "Auto-minimize when no open daily present?",
-							tooltip = "Check this if you want the DASWindow to be minimized when you're done. Will obviously be overridden by hide.",
-							getFunc = function() return DAS.GetAutoMinimize() end,
-							setFunc = function(value) DAS.SetAutoMinimize(value) end
-						},
-						{ -- checkbox: hide completed
-							type    = "checkbox",
-							name    = "Hide completed quests?",
-							tooltip = "Usually, completed dailies will be shown in the list. Check this to make them vanish.",
-							getFunc = function() return DAS.GetHideCompleted() end,
-							setFunc = function(value) DAS.SetHideCompleted(value) end
-						},
-						{ -- slider: font size
-							type 	= "slider",
-							name 	= "Font size",
-							tooltip = "adjust font size",
-							min 	= 50,
-							step	= 5,
-							max 	= 250,
-							getFunc = function() return DAS.GetFontSize()*100 end,
-							setFunc = function(value) DAS.SetFontSize(value/100) end
-						},
-      					},
-    				}, -- submenu UI settings end
-				{ -- behavior if hidden
-					type    = "submenu",
-					name    = "Behavior in inactive zones",
-					controls = 
-					{
-						{ -- checkbox: hide completed
-							type    = "checkbox",
-							name    = "Hide?",
-							tooltip = "Usually, completed dailies will be shown in the list. Check this to make them vanish.",
-							getFunc = function() return DAS.GetHiddenInInactiveZones() end,
-							setFunc = function(value) DAS.SetHiddenInInactiveZones(value) end
-						},
-      					}
-    				},
-		{ -- submenu: Guild settings
+	local panelData = {
+		type               = "panel",
+		name               = DAS.name,
+		displayName        = "Daily|c89FFE3Auto|rShare",
+		author             = DAS.author,
+		version            = DAS.version,
+		website            = 'https://www.esoui.com/downloads/fileinfo.php?id=1340',
+		feedback           = 'https://github.com/manavortex/DailyAutoShare/issues',
+		translation        = 'https://github.com/manavortex/DailyAutoShare/pulls',
+		slashCommand       = "/das_menu",
+		registerForRefresh = true,
+	}
+	local optionsData = {
+		{
+			type    = "header",
+			name    = "General Settings"
+		},
+		{
+			type    = "checkbox",
+			tooltip = "Use the same settings for all characters?",
+			name    = "Account-wide Settings",
+			width   = "half",
+			getFunc = function() return DAS.GetUseGlobalSettings() end,
+			setFunc = function(value) DAS.SetUseGlobalSettings(value) end
+		},
+		{
+			type    = "checkbox",
+			name    = "Hide UI window",
+			width   = "half",
+			getFunc = function() return DAS.GetHidden() end,
+			setFunc = function(value) DAS.SetHidden(value) end
+		},
+		{ -- activate menu
 			type    = "submenu",
-			name    = " Guild settings",
-			controls = {
-				{ -- checkbox: Mute add-on output?
+			name    = "Activate DailyAutoShare in...",
+			tooltip = GetString(DAS_MENU_ACTIV_EXPLAIN),
+			controls =
+			{
+				{
+					type    = "header",
+					name    = "Zones:"
+				},
+				{
+					type    = "checkbox",
+					tooltip = "Blackwood Chapter",
+					name    = "Blackwood",
+					getFunc = function() return DAS.GetActiveIn(1261) end,
+					setFunc = function(value) DAS.SetActiveIn(1261, value) end
+				},
+				{
+					type    = "checkbox",
+					tooltip = "Clockwork City DLC",
+					name    = "Clockwork City",
+					getFunc = function() return DAS.GetActiveIn(980) end,
+					setFunc = function(value)
+						DAS.SetActiveIn(980, value)
+						DAS.SetActiveIn(981, value)
+						DAS.SetActiveIn(983, value)
+					end
+				},
+				{ -- submenu: Clockwork City
+					type     = "submenu",
+					name     = "Clockwork City Options",
+					disabled = function() return (not DAS.GetActiveIn(980)) end,
+					controls =
+					{
+						{
+							type    = "header",
+							name    = "Brass Fortress: Delves"
+						},
+						{
+							type    = "checkbox",
+							name    = "Enable",
+							tooltip = zo_strformat("Quest giver is |cFFFFFF<<1>>|r in the Brass Fortress\nRequires completing the following prerequisite quests (either of):\n• <<2>>\n• <<3>>", GetString(DAS_QUEST_CC_NOVICE), GetQuestName(6058), GetQuestName(6049)),
+							width   = "half",
+							getFunc = function() return DAS.GetQuestListItem(980, "delve", "active") end,
+							setFunc = function(value) DAS.SetQuestListItem(980, "delve", "active", value) end
+						},
+						{
+							type     = "checkbox",
+							name     = "Hide",
+							tooltip  = "Hide the quests from UI List but keep sharing them",
+							width    = "half",
+							disabled = function() return not DAS.GetQuestListItem(980, "delve", "active") end,
+							getFunc  = function() return DAS.GetQuestListItem(980, "delve", "invisible") end,
+							setFunc  = function(value) DAS.SetQuestListItem(980, "delve", "invisible", value) end
+						},
+						{
+							type    = "header",
+							name    = "Brass Fortress: World Bosses"
+						},
+						{
+							type    = "checkbox",
+							name    = "Enable",
+							tooltip = zo_strformat("Quest giver is |cFFFFFF<<1>>|r in the Brass Fortress", GetString(DAS_QUEST_CC_ROBOT)),
+							width   = "half",
+							getFunc = function() return DAS.GetQuestListItem(980, "boss", "active") end,
+							setFunc = function(value) DAS.SetQuestListItem(980, "boss", "active", value) end
+						},
+						{
+							type     = "checkbox",
+							name     = "Hide",
+							tooltip  = "Hide the quests from UI List but keep sharing them",
+							width    = "half",
+							disabled = function() return not DAS.GetQuestListItem(980, "boss", "active") end,
+							getFunc  = function() return DAS.GetQuestListItem(980, "boss", "invisible") end,
+							setFunc  = function(value) DAS.SetQuestListItem(980, "boss", "invisible", value) end
+						},
+						{
+							type    = "header",
+							name    = "Slag Town: Gathering dailies"
+						},
+						{
+							type    = "checkbox",
+							name    = "Enable",
+							tooltip = zo_strformat("Quest giver is |cFFFFFF<<1>>|r in the Brass Fortress", GetString(DAS_QUEST_CC_ORC)),
+							width   = "half",
+							getFunc = function() return DAS.GetQuestListItem(980, "craft", "active") end,
+							setFunc = function(value) DAS.SetQuestListItem(980, "craft", "active", value) end
+						},
+						{
+							type     = "checkbox",
+							name     = "Hide",
+							tooltip  = "Hide the quests from UI List but keep sharing them",
+							width    = "half",
+							disabled = function() return not DAS.GetQuestListItem(980, "craft", "active") end,
+							getFunc  = function() return DAS.GetQuestListItem(980, "craft", "invisible") end,
+							setFunc  = function(value) DAS.SetQuestListItem(980, "craft", "invisible", value) end
+						},
+						{
+							type    = "header",
+							name    = "Slag Town: Blackfeather Court"
+						},
+						{
+							type    = "checkbox",
+							name    = "Enable",
+							tooltip = zo_strformat("Quest giver is |cFFFFFF<<1>>|r in the Brass Fortress\nRequires progressing the zone story past the following quest:\n• <<2>>", GetString(DAS_QUEST_CC_CROW), GetQuestName(6052)),
+							width   = "half",
+							getFunc = function() return DAS.GetQuestListItem(980, "crow", "active") end,
+							setFunc = function(value) DAS.SetQuestListItem(980, "crow", "active", value) end
+						},
+						{
+							type     = "checkbox",
+							name     = "Hide",
+							tooltip  = "Hide the quests from UI List but keep sharing them",
+							width    = "half",
+							disabled = function() return not DAS.GetQuestListItem(980, "crow", "active") end,
+							getFunc  = function() return DAS.GetQuestListItem(980, "crow", "invisible") end,
+							setFunc  = function(value) DAS.SetQuestListItem(980, "crow", "invisible", value) end
+						},
+					},
+				}, -- end of submenu : Clockwork City
+				{
+					type    = "checkbox",
+					name    = "Craglorn",
+					getFunc = function() return DAS.GetActiveIn(888) end,
+					setFunc = function(value) DAS.SetActiveIn(888, value) end
+				},
+				{
+					type    = "checkbox",
+					tooltip = "Auto-accept and turn-in support only",
+					name    = "Cyrodiil Alliance Base",
+					getFunc = function() return DAS.GetActiveIn(181) end,
+					setFunc = function(value) DAS.SetActiveIn(181, value) end
+				},
+				{
+					type    = "checkbox",
+					tooltip = "Dark Brotherhood DLC",
+					name    = "Gold Coast",
+					getFunc = function() return DAS.GetActiveIn(823) end,
+					setFunc = function(value) DAS.SetActiveIn(823, value) end
+				},
+				{
+					type    = "checkbox",
+					tooltip = "Murkmire DLC",
+					name    = "Murkmire",
+					getFunc = function() return DAS.GetActiveIn(726) end,
+					setFunc = function(value) DAS.SetActiveIn(726, value) end
+				},
+				{ -- submenu: Murkmire
+					type     = "submenu",
+					name     = "Murkmire Options",
+					disabled = function() return (not DAS.GetActiveIn(726)) end,
+					controls =
+					{
+						{
+							type    = "header",
+							name    = "Lilmoth: Delves"
+						},
+						{
+							type    = "checkbox",
+							name    = "Enable",
+							tooltip = zo_strformat("Quest giver is |cFFFFFF<<1>>|r in Lilmoth\nRequires completing the following prerequisite quest:\n• <<2>>", GetString(DAS_SLAVES_QUEST1), GetQuestName(6295)),
+							width   = "half",
+							getFunc = function() return DAS.GetQuestListItem(726, "delve", "active") end,
+							setFunc = function(value) DAS.SetQuestListItem(726,   "delve", "active", value) end
+						},
+						{
+							type     = "checkbox",
+							name     = "Hide",
+							tooltip  = "Hide the quests from UI List but keep sharing them",
+							width    = "half",
+							disabled = function() return not DAS.GetQuestListItem(726, "delve", "active") end,
+							getFunc  = function() return DAS.GetQuestListItem(726, "delve", "invisible") end,
+							setFunc  = function(value) DAS.SetQuestListItem(726,   "delve", "invisible", value) end
+						},
+						{
+							type    = "header",
+							name    = "Lilmoth: World Bosses"
+						},
+						{
+							type    = "checkbox",
+							name    = "Enable",
+							tooltip = zo_strformat("Quest giver is |cFFFFFF<<1>>|r in Lilmoth\nRequires completing the following prerequisite quest:\n• <<2>>", GetString(DAS_SLAVES_QUEST3), GetQuestName(6295)),
+							width   = "half",
+							getFunc = function() return DAS.GetQuestListItem(726, "boss", "active") end,
+							setFunc = function(value)   DAS.SetQuestListItem(726, "boss", "active", value) end
+						},
+						{
+							type     = "checkbox",
+							name     = "Hide",
+							tooltip  = "Hide the quests from UI List but keep sharing them",
+							width    = "half",
+							disabled = function() return not DAS.GetQuestListItem(726, "boss", "active") end,
+							getFunc  = function() return DAS.GetQuestListItem(726, "boss", "invisible") end,
+							setFunc  = function(value) DAS.SetQuestListItem(726,   "boss", "invisible", value) end
+						},
+						{
+							type    = "header",
+							name    = "Root-Whisper Village"
+						},
+						{
+							type    = "checkbox",
+							name    = "Enable",
+							tooltip = zo_strformat("Quest giver is |cFFFFFF<<1>>|r in Root-Whisper Village\nRequires completing the zone story", GetString(DAS_SLAVES_QUEST2)),
+							width   = "half",
+							getFunc = function() return DAS.GetQuestListItem(726, "root", "active") end,
+							setFunc = function(value) DAS.SetQuestListItem(726,   "root", "active", value) end
+						},
+						{
+							type     = "checkbox",
+							name     = "Hide",
+							tooltip  = "Hide the quests from UI List but keep sharing them",
+							width    = "half",
+							disabled = function() return not DAS.GetQuestListItem(726, "root", "active") end,
+							getFunc  = function() return DAS.GetQuestListItem(726, "root", "invisible") end,
+							setFunc  = function(value) DAS.SetQuestListItem(726,   "root", "invisible", value) end
+						},
+					},
+				},-- end of submenu murkmire
+				{
+					type    = "checkbox",
+					tooltip = "Elsweyr DLC",
+					name    = "Northern Elsweyr",
+					getFunc = function() return DAS.GetActiveIn(1086) end,
+					setFunc = function(value) DAS.SetActiveIn(1086, value) end
+				},
+				{
+					type    = "checkbox",
+					tooltip = "Dragonhold DLC",
+					name    = "Southern Elsweyr",
+					getFunc = function() return DAS.GetActiveIn(1133) end,
+					setFunc = function(value) DAS.SetActiveIn(1133, value) end
+				},
+				{
+					type    = "checkbox",
+					tooltip = "Summerset DLC",
+					name    = "Summerset",
+					getFunc = function() return DAS.GetActiveIn(1011) end,
+					setFunc = function(value) DAS.SetActiveIn(1011, value) end
+				},
+				{
+					type    = "checkbox",
+					tooltip = "Morrowind DLC",
+					name    = "Vvardenfell",
+					getFunc = function() return DAS.GetActiveIn(849) end,
+					setFunc = function(value) DAS.SetActiveIn(849, value) end
+				},
+				{ -- submenu: Morrowind
+					type     = "submenu",
+					name     = "Vvardenfell Options",
+					disabled = function() return (not DAS.GetActiveIn(849)) end,
+					controls =
+					{
+						{
+							type    = "header",
+							name    = "Ashlander: Relics",
+						},
+						{
+							type    = "checkbox",
+							tooltip = zo_strformat("Quest giver is |cFFFFFF<<1>>|r in Ald'ruhn\nRequires completing the following prerequisite quests:\n• <<2>>\n• <<3>>", GetString(DAS_QUEST_M_NUMANI), GetQuestName(5885), GetQuestName(6008)),
+							name    = "Enable",
+							width   = "half",
+							getFunc = function() return DAS.GetQuestListItem(849, "relic", "active") end,
+							setFunc = function(value) DAS.SetQuestListItem(849, "relic", "active", value) end
+						},
+						{
+							type     = "checkbox",
+							name     = "Hide",
+							tooltip  = "Hide the quests from UI List but keep sharing them",
+							width    = "half",
+							disabled = function() return not DAS.GetQuestListItem(849, "relic", "active") end,
+							getFunc  = function() return DAS.GetQuestListItem(849, "relic", "invisible") end,
+							setFunc  = function(value) DAS.SetQuestListItem(849, "relic", "invisible", value) end
+						},
+						{
+							type    = "header",
+							name    = "Ashlander: Hunt"
+						},
+						{
+							type    = "checkbox",
+							name    = "Enable",
+							tooltip = zo_strformat("Quest giver is |cFFFFFF<<1>>|r in Ald'ruhn\nRequires completing the following prerequisite quests:\n• <<2>>\n• <<3>>", GetString(DAS_QUEST_M_ASHLANDER), GetQuestName(5885), GetQuestName(6008)),
+							width   = "half",
+							getFunc = function() return DAS.GetQuestListItem(849, "hunt", "active") end,
+							setFunc = function(value) DAS.SetQuestListItem(849, "hunt", "active", value) end
+						},
+						{
+							type     = "checkbox",
+							name     = "Hide",
+							tooltip  = "Hide the quests from UI List but keep sharing them",
+							width    = "half",
+							disabled = function() return not DAS.GetQuestListItem(849, "hunt", "active") end,
+							getFunc  = function() return DAS.GetQuestListItem(849, "hunt", "invisible") end,
+							setFunc  = function(value) DAS.SetQuestListItem(849, "hunt", "invisible", value) end
+						},
+						{
+							type    = "header",
+							name    = "Vivec: Delves"
+						},
+						{
+							type    = "checkbox",
+							name    = "Enable",
+							tooltip = zo_strformat("Quest giver is |cFFFFFF<<1>>|r in Vivec's Hall of Justice\nRequires completing the following prerequisite quest:\n• <<2>>", GetString(DAS_QUEST_M_TRAYLAN), GetQuestName(6007)),
+							width   = "half",
+							getFunc = function() return DAS.GetQuestListItem(849, "delve", "active") end,
+							setFunc = function(value) DAS.SetQuestListItem(849, "delve", "active", value) end
+						},
+						{
+							type     = "checkbox",
+							name     = "Hide",
+							tooltip  = "Hide the quests from UI List but keep sharing them",
+							width    = "half",
+							disabled = function() return not DAS.GetQuestListItem(849, "delve", "active") end,
+							getFunc  = function() return DAS.GetQuestListItem(849, "delve", "invisible") end,
+							setFunc  = function(value) DAS.SetQuestListItem(849, "delve", "invisible", value) end
+						},
+						{
+							type    = "header",
+							name    = "Vivec: World Bosses"
+						},
+						{
+							type    = "checkbox",
+							name    = "Enable",
+							tooltip = zo_strformat("Quest giver is |cFFFFFF<<1>>|r in Vivec's Hall of Justice\nRequires completing the following prerequisite quest:\n• <<2>>", GetString(DAS_QUEST_M_BELERU), GetQuestName(6007)),
+							width   = "half",
+							getFunc = function() return DAS.GetQuestListItem(849, "boss", "active") end,
+							setFunc = function(value) DAS.SetQuestListItem(849, "boss", "active", value) end
+						},
+						{
+							type     = "checkbox",
+							name     = "Hide",
+							tooltip  = "Hide the quests from UI List but keep sharing them",
+							width    = "half",
+							disabled = function() return not DAS.GetQuestListItem(849, "boss", "active") end,
+							getFunc  = function() return DAS.GetQuestListItem(849, "boss", "invisible") end,
+							setFunc  = function(value) DAS.SetQuestListItem(849, "boss", "invisible", value) end
+						},
+					},
+				}, -- end of submenu : Morrowind
+				{
+					type    = "checkbox",
+					tooltip = "Orsinium DLC",
+					name    = "Wrothgar",
+					getFunc = function() return DAS.GetActiveIn(684) end,
+					setFunc = function(value) DAS.SetActiveIn(684, value) end
+				},
+				{
+					type    = "header",
+					name    = "Guild activities:"
+				},
+				{
+					type    = "checkbox",
+					name    = "Fighters / Mages Guilds & Undaunted",
+					getFunc = function() return DAS.GetActiveIn("guilds") end,
+					setFunc = function(value) DAS.SetActiveFor("guilds", value) end
+				},
+				{ -- Submenu : Guild Dailies
+					type        = "submenu",
+					name        = "Guild dailies options",
+					disabled    = function() return not DAS.GetActiveIn("guilds") end,
+					controls    =
+					{
+						{
+							type     = "checkbox",
+							tooltip  = "Hide the quests from UI List but keep sharing them",
+							name     = "Hide Fighters Guild dailies in Capitals",
+							getFunc  = function() return DAS.GetQuestListItem(57, "fg", "invisible") end,
+							setFunc  = function(value)
+								DAS.SetQuestListItem(57, "fg", "invisible", value)
+								DAS.SetQuestListItem(19, "fg", "invisible", value)
+								DAS.SetQuestListItem(383, "fg", "invisible", value)
+							end
+						},
+						{
+							type     = "checkbox",
+							tooltip  = "Hide the quests from UI List but keep sharing them",
+							name     = "Hide Mages Guild dailies in Capitals",
+							getFunc  = function() return DAS.GetQuestListItem(57, "mg", "invisible") end,
+							setFunc  = function(value)
+								DAS.SetQuestListItem(57, "mg", "invisible", value)
+								DAS.SetQuestListItem(19, "mg", "invisible", value)
+								DAS.SetQuestListItem(383, "mg", "invisible", value)
+							end
+						},
+						{
+							type     = "checkbox",
+							tooltip  = "Hide the quests from UI List but keep sharing them",
+							name     = "Hide Undaunted dailies in Capitals",
+							getFunc  = function() return DAS.GetQuestListItem(57, "ud", "invisible") end,
+							setFunc  = function(value)
+								DAS.SetQuestListItem(57, "ud", "invisible", value)
+								DAS.SetQuestListItem(19, "ud", "invisible", value)
+								DAS.SetQuestListItem(383, "ud", "invisible", value)
+							end
+						},
+					},
+				}, -- end of submenu : Guild Dailies
+				{
+					type    = "header",
+					name    = "Festivals:"
+				},
+				{
+					type    = "checkbox",
+					name    = "New Life",
+					tooltip = "Enable New Life festival",
+					getFunc = function() return DAS.GetActiveIn("newLife") end,
+					setFunc = function(value) DAS.SetActiveFor("newLife", value) end
+				},
+			}, -- end of activate menu
+		},
+		{
+			type    = "checkbox",
+			name    = "Hide in non-active zones",
+			tooltip = "Usually the completed dailies will be shown in the list. Check this to make them vanish.",
+			getFunc = function() return DAS.GetHiddenInInactiveZones() end,
+			setFunc = function(value) DAS.SetHiddenInInactiveZones(value) end
+		},
+		{ -- behaviour menu
+			type     = "submenu",
+			name     = "Invitation text & behaviour",
+			controls =
+			{
+				{
+					type        = "editbox",
+					isExtraWide = true,
+					name        = "Quest Share text",
+					tooltip     = ("Text to generate when you spam quest shares.\n"
+					.. "<<1>> will be replaced with the quest names, <<2>> with the bingo codes.\n"
+					.. "Omit either to remove parameter. Include neither and sound like a fool."),
+					getFunc     = function() return DAS.GetSettings().questShareString end,
+					setFunc     = function(value) DAS.GetSettings().questShareString = value end,
+				},
+				{
+					type    = "button",
+					name    = "Reset",
+					tooltip = "Reset Quest Share text to its default value",
+					func    = function() DAS.GetSettings().questShareString = defaults.questShareString end,
+				},
+				{
+					type    = "checkbox",
+					name    = "Use Whisper-only Mode",
+					tooltip = "This will ignore bingo spam in the zone chat!",
+					getFunc = function() return DAS.GetWhisperOnly() end,
+					setFunc = function(value) DAS.GetSettings().whisperOnly = value end
+				},
+				{
+					type        = "editbox",
+					isExtraWide = true,
+					name        = "Whisper-only text",
+					disabled    = function() return not DAS.GetWhisperOnly() end,
+					tooltip     = "Will replace everything after <<1>> in the Quest Share text above",
+					getFunc     = function() return DAS.GetSettings().whisperString end,
+					setFunc     = function(value) DAS.GetSettings().whisperString = value end,
+				},
+				{
+					type    = "header",
+					name    = "Auto-Invite from Guild Chat"
+				},
+				{
 					type    = "dropdown",
 					tooltip = "Which guild should the add-on listen to?",
-					choices = {"1","2","3","4","5",},
-					name    = "Auto-invite for guild...",
+					choices = {
+						"(none)",
+						GetGuildName(GetGuildId(1)),
+						GetGuildName(GetGuildId(2)),
+						GetGuildName(GetGuildId(3)),
+						GetGuildName(GetGuildId(4)),
+						GetGuildName(GetGuildId(5))
+					},
+					choicesValues = {
+						0,
+						1,
+						2,
+						3,
+						4,
+						5
+					},
+					name    = "Auto-invite from the guild chat of...",
 					getFunc = function() return DAS.GetGuildInviteNumber() end,
-					setFunc = function(value) DAS.SetGuildInviteNumber(value) end
-        },
-				{ -- checkbox: Lock UI window
-					type    = "editbox",
-					tooltip = "Invite on what..? Leave blank to disable invite. \nNeeds to be like 'word', will invite on '+word'",
-					name    = "invite string",
-					getFunc = function() return DAS.GetGuildInviteText() end,
-					setFunc = function(value) DAS.SetGuildInviteText(value) end
-        },
-				{ -- checkbox: inviteFromGuild
+					setFunc = function(value) DAS.SetGuildInviteNumber(value) end,
+				},
+				{
+					type     = "editbox",
+					name     = "Auto-invite code",
+					tooltip  = "Leave blank to disable.\nSet as |cFFFFFFblah|r to auto-invite on |cFFFFFF+blah|r and so on",
+					disabled = function() return 0 == DAS.GetGuildInviteNumber() end,
+					getFunc  = function() return DAS.GetGuildInviteText() end,
+					setFunc  = function(value) DAS.SetGuildInviteText(value) end
+				},
+				{
 					type    = "checkbox",
-					tooltip = "do the bingo thing in guilds?",
-					name    = "listen in guild chat",
+					name    = "Listen for bingo codes in all guild chats",
 					getFunc = function() return DAS.GetListenInGuilds() end,
 					setFunc = function(value) DAS.SetListenInGuilds(value) end
-        },
-      },
-    }, -- submenu UI settings end
-		{ -- header: automatically
+				},
+			},
+		}, -- end of behaviour menu
+		{ -- window menu
+			type        = "submenu",
+			name        = "DAS Window's Look and Feel",
+			controls    =
+			{
+				-- {
+				-- 	type    = "checkbox",
+				-- 	name    = "Show Map markers?",
+				-- 	getFunc = function() return DAS.GetMarkerVisibility() end,
+				-- 	setFunc = function(value) DAS.SetMarkerVisibility(value) end
+				-- },
+				{
+					type    = "checkbox",
+					name    = "Lock window position",
+					getFunc = function() return DAS.GetLocked() end,
+					setFunc = function(value) DAS.SetLocked(value) end
+				},
+				{
+					type    = "checkbox",
+					name    = "Draw tooltips and sublists on the right side",
+					tooltip = "Switch this off to display tooltips and sublists on the left instead",
+					getFunc = function() return DAS.GetSettings().tooltipRight end,
+					setFunc = function(value)
+						DAS.GetSettings().tooltipRight = value
+						DAS.AnchorList()
+					end
+				},
+				{
+					type    = "checkbox",
+					name    = "DropUp instead of DropDown",
+					tooltip = "Check this if you want the questList to appear above the drag bar instead of below",
+					getFunc = function() return DAS.GetUpsideDown() end,
+					setFunc = function(value) DAS.SetUpsideDown(value) end
+				},
+				{
+					type    = "checkbox",
+					name    = "Start up minimised",
+					tooltip = "Always minimise the DAS Window on first startup",
+					getFunc = function() return DAS.GetSettings().startupMinimized end,
+					setFunc = function(value) DAS.GetSettings().startupMinimized = value end
+				},
+				{
+					type    = "checkbox",
+					name    = "Auto-hide if all dailies are complete",
+					tooltip = "Check this if you want the DAS Window to be hidden when you're done",
+					getFunc = function() return DAS.GetAutoHide() end,
+					setFunc = function(value) DAS.SetAutoHide(value) end
+				},
+				{
+					type     = "checkbox",
+					name     = "Auto-minimise if all dailies are complete",
+					tooltip  = "Check this if you want the DAS Window to be minimised when you're done. Will obviously be overridden by hide.",
+					disabled = function() return DAS.GetAutoHide() end,
+					getFunc  = function() return DAS.GetAutoMinimize() end,
+					setFunc  = function(value) DAS.SetAutoMinimize(value) end
+				},
+				{
+					type    = "checkbox",
+					name    = "Hide the completed quests",
+					tooltip = "Usually the completed dailies are shown in the list. Check this to make them vanish.",
+					getFunc = function() return DAS.GetHideCompleted() end,
+					setFunc = function(value) DAS.SetHideCompleted(value) end
+				},
+				{
+					type 	= "slider",
+					name 	= "Font size",
+					tooltip = "Make the text bigger or smaller. 80 is a good starting point for zones like Vvardenfell.",
+					min 	= 50,
+					step	= 5,
+					max 	= 250,
+					getFunc = function() return DAS.GetFontSize()*100 end,
+					setFunc = function(value) DAS.SetFontSize(value/100) end
+				},
+			},
+		}, -- end of window menu
+		{
 			type    = "header",
-			name    = "automatically..."
-    },
-		{ -- auto-accept
+			name    = "Automatically..."
+		},
+		{
 			type    = "checkbox",
-			tooltip = "Accept repeatable quest if they are shared?",
+			tooltip = "Accept repeatable quests when they are shared?",
 			name    = "accept shared dailies",
 			getFunc = function() return DAS.GetAutoAcceptShared() end,
 			setFunc = function(value) DAS.SetAutoAcceptShared(value) end
-    },
-		{ -- accept dailies from questgiver
+		},
+		{
 			type    = "checkbox",
-			tooltip = "Skip quest accept dialogue? \n Needs localization to work",
-			name    = "accept dailies from questgiver?",
+			tooltip = "Skip all dialogue for the daily quest NPCs?",
+			name    = "accept dailies from questgivers",
 			getFunc = function() return DAS.GetSettings().autoAcceptQuest end,
 			setFunc = function(value) DAS.GetSettings().autoAcceptQuest = value end
-    },
-		{ --auto-invite
+		},
+		{
 			type    = "checkbox",
-			tooltip = "Are you the active kind? Check this box to auto-invite",
+			tooltip = "Are you the active kind? Check this box to auto-invite\nDoes the same thing as the toggle button in DAS Window",
 			name    = "invite from zone chat",
 			getFunc = function() return DAS.GetAutoInvite() end,
 			setFunc = function(value) DAS.SetAutoInvite(value) end
-    },
-		{ --Stop inviting
+		},
+		{
 			type    = "checkbox",
-			tooltip = "Stop inviting when you leave a group?",
+			tooltip = "Deactivate auto-invite when you leave the group?",
 			name    = "stop inviting when the group disbands",
 			getFunc = function() return DAS.GetStopInviteOnDegroup() end,
 			setFunc = function(value) DAS.SetStopInviteOnDegroup(value) end
-    },
-		{ --auto-leave
+		},
+		{
 			type    = "checkbox",
-			tooltip = "Automatically leave group when you're searching while still grouped?",
-			name    = "groupleave on new search",
+			tooltip = "Automatically leave the group when you're searching while still grouped?",
+			name    = "groupleave on a new search",
 			getFunc = function() return DAS.GetAutoLeave() end,
 			setFunc = function(value) DAS.SetAutoLeave(value) end
-    },
-		{ -- auto-accept interval
+		},
+		{
 			type    = "slider",
 			tooltip = ("After you've been looking for quest share, "
-        .. "how long do you want to automatically accept group-invites?\n"
-      .. "Set to 0 to disable"),
+			.. "how long do you want to automatically accept group-invites?\n"
+			.. "Set to 0 to disable"),
 			name    = "Accept auto-invite after +bingo in zone for ... seconds",
 			min     = 0,
 			max     = 60,
 			getFunc = function() return DAS.GetAutoAcceptInviteInterval() end,
 			setFunc = function(value) DAS.SetAutoAcceptInviteInterval(value) end
-    },
-  } -- optionsData end
+		},
+		{
+			type    = "header",
+			name    = "Throttle"
+		},
+		{
+			type 	= "slider",
+			name 	= "Group invite delay (in ms)",
+			tooltip = "Adjust this if you encounter disconnects when trying to create a group.\n1000 ms are one second.",
+			min 	= 250,
+			step	= 10,
+			max 	= 2500,
+			getFunc = function() return DAS.GetGroupInviteDelay() end,
+			setFunc = function(value) DAS.SetGroupInviteDelay(value) end
+		},
+		{
+			type 	= "slider",
+			name 	= "Quest share delay (in ms)",
+			tooltip = "Adjust this if you encounter disconnects when new group members join.\n1000 ms are one second.",
+			min 	= 250,
+			step	= 10,
+			max 	= 2500,
+			getFunc = function() return DAS.GetQuestShareDelay() end,
+			setFunc = function(value) DAS.SetQuestShareDelay(value) end
+		},
+		{
+			type    = "header",
+			name    = "Miscellaneous"
+		},
+		{
+			type    = "checkbox",
+			name    = "Debug Mode",
+			getFunc = function() return DAS.GetDebugMode() end,
+			setFunc = function(value) DAS.SetDebugMode(value) end
+		},
+	} -- optionsData end
+	LAM:RegisterAddonPanel("DailyAutoShare_OptionsPanel", panelData)
 	LAM:RegisterOptionControls("DailyAutoShare_OptionsPanel", optionsData)
 end


### PR DESCRIPTION
HowlyBlood moved the zone options into the advanced settings sub-menu, and that's about it. This resulted in activation settings being 3 levels deep, a nightmare to navigate.

I started by resorting the zone list to make it more logical, and a few hours later I arrived at a drastically different layout.

A number of options were made functional, a few LUA errors and typos were squashed in the process.

The next step will be to tokenise all this for localisation.

Before:
![image](https://user-images.githubusercontent.com/2910415/132928886-9caab599-f6d9-489d-9c9b-b4dba6137f31.png)
![image](https://user-images.githubusercontent.com/2910415/132928893-aa288a38-12ae-4e9e-a0f8-036d7a3059c8.png)
![image](https://user-images.githubusercontent.com/2910415/132928904-dae8dc9b-60b4-4b84-99d4-c82145a1fbf1.png)
![image](https://user-images.githubusercontent.com/2910415/132928920-efb42184-dca3-4c28-8922-ebbcba056fce.png)

After:
![image](https://user-images.githubusercontent.com/2910415/132928941-980198e3-6b02-4739-88cc-cec4776d8e2e.png)
![image](https://user-images.githubusercontent.com/2910415/132928954-272af4cd-507a-406f-a7ab-e61fa4ef7c85.png)
![image](https://user-images.githubusercontent.com/2910415/132928965-e97d513a-fe92-4f0b-bcd2-f13784b65382.png)

