### PR TITLE
Fix GLOBAL namespace pollution

### DIFF
--- a/DASData.lua
+++ b/DASData.lua
@@ -1,7 +1,6 @@
 local DAS = DailyAutoShare
 local p   = DAS.DebugOut
 function DAS.GetZoneId()  return GetZoneId(GetUnitZoneIndex(UNITTAG_PLAYER)) or 0 end
-function PrintZoneId()    d(GetZoneId(GetUnitZoneIndex(UNITTAG_PLAYER))) end
 local typeTable   = "table"
 local typeString  = "string"
 local function evaluateNestedLists(tbl)
@@ -65,6 +64,15 @@ function DAS.IsQuestActive(questName)
 	end
 	return true
 end
+function DAS.GetBingoIndexFromMessage(messageText)
+	local bingoArray = DAS.bingo[DAS.GetZoneId()]
+	if nil == bingoArray then return end
+	for bingo, questindex in pairs(bingoArray) do
+		if messageText:match(bingo) then
+			return questindex
+		end
+	end
+end
 function DAS.GetBingoIndexFromQuestName(questName)
 	for questIndex, checkQuestName in pairs(DAS.GetZoneQuests()) do
 		if questName == checkQuestName then
@@ -113,7 +121,7 @@ function DAS.GetQuestNameFromIndex(bingoIndex)
 	return DAS.GetZoneQuests()[bingoIndex] 
 end
 function DAS.GetQuestNameFromBingoString(bingoString)
-	local bingoIndex = GetBingoIndexFromMessage(bingoString)
+	local bingoIndex = DAS.GetBingoIndexFromMessage(bingoString)
 	if nil == bingoIndex then return end
 	return DAS.GetQuestNameFromIndex(bingoIndex)
 end

--- a/DASHelper.lua
+++ b/DASHelper.lua
@@ -16,7 +16,7 @@ end
 -- DAS_STATUS_ACTIVE 	= 2,
 -- DAS_STATUS_TRACKED 	= 3
 local refreshedRecently = false
-function refreshQuestLogs(forceOverride)
+local function refreshQuestLogs(forceOverride)
 	forceOverride 			= forceOverride or DAS.questCacheNeedsRefresh or DAS.QuestIndexTable == {} or DAS.QuestNameTable == {}
 	if forceOverride 		then refreshedRecently = false end
 	if refreshedRecently 	then return end
@@ -25,7 +25,7 @@ function refreshQuestLogs(forceOverride)
 	DAS.QuestNameTable		= {}
 	for i=1, 25 do
 		if IsValidQuestIndex(i) then
-			journalQuestName, _, _, _, _, _, tracked = GetJournalQuestInfo(i)
+			local journalQuestName, _, _, _, _, _, tracked = GetJournalQuestInfo(i)
 			journalQuestName = zo_strformat(journalQuestName)
 			DAS.QuestIndexTable[i] = journalQuestName
 			DAS.QuestNameTable[journalQuestName] = i
@@ -123,8 +123,8 @@ local function EscapeString(text)
 	return text or ""
  end
 function DAS.IsMatch(param1, param2)
-	string1 = EscapeString(tostring(param1):lower())
-	string2 = EscapeString(tostring(param2):lower())
+	local string1 = EscapeString(tostring(param1):lower())
+	local string2 = EscapeString(tostring(param2):lower())
 	if #string1 == 0 or #string2 == 0 then return false end
 	return string.match(string1, string2) or string.match(string2, string2) or string1 == string2
  end

--- a/DasGui.lua
+++ b/DasGui.lua
@@ -83,9 +83,7 @@ function DAS.QuestLabelClicked(control, mouseButton)
 		return DAS.OnRightClick(control)
   end
 	if (nil ~= control.dataQuestList and {} ~= control.dataQuestList) then
-		DAS.SetSubLabels(control.dataQuestList)
-		DasSubList:SetHidden(false)
-		DAS.setFontSize(DAS.sublabels)
+		return DAS.RefreshSubLabels(control)
 	end
 	local journalIndex          = control.dataJournalIndex or 99
 	if IsValidQuestIndex(journalIndex) then
@@ -95,6 +93,12 @@ function DAS.QuestLabelClicked(control, mouseButton)
       ShareQuest(journalIndex)
     end
   end
+end
+function DAS.RefreshSubLabels(control)
+	DasSubList.dataCurrentList = control
+	DAS.SetSubLabels(control.dataQuestList)
+	DasSubList:SetHidden(false)
+	DAS.setFontSize(DAS.sublabels)
 end
 function DAS.Donate(control, mouseButton)
 	local amount = 2000
@@ -156,7 +160,7 @@ local function setControlText(label, hidden)
     label:SetState(BSTATE_NORMAL)
   end
 end
-function setLabelTable(questTable)
+local function setLabelTable(questTable)
   local status = DAS_STATUS_COMPLETE
   local index = 1
   local questName, tmpStatus = nil
@@ -233,7 +237,7 @@ function DAS.setLabels(zoneQuests)
   local questName
 	for index, questNameOrTable in pairs(zoneQuests) do
     if not labelTexts[questNameOrTable] then
-      label = DAS.labels[numLabels] -- despite the name these are actually buttons
+      local label = DAS.labels[numLabels] -- despite the name these are actually buttons
       if nil ~= label then
         local status                      = DAS_STATUS_OPEN
         visibleButtonIndex 			          = visibleButtonIndex +1
@@ -252,9 +256,7 @@ function DAS.setLabels(zoneQuests)
         -- d(zo_strformat("DAS: <<1>> state <<2>>", label.dataQuestName, label.dataQuestState))
         label:SetHidden(hideLabel)
         label.dataJournalIndex 	= DAS.GetLogIndex(label.dataQuestName)
-        bingoString, bingoIndex = DAS.GetBingoStringFromQuestName(label.dataQuestName)
-        label.dataBingoString 	= bingoString
-        label.dataBingoIndex 	= bingoIndex
+        label.dataBingoString, label.dataBingoIndex = DAS.GetBingoStringFromQuestName(label.dataQuestName)
         label.dataTitle         = label.dataTitle or ""
         if label.dataQuestState == DAS_STATUS_ACTIVE then
           table.insert(DAS.activeZoneQuests, label.dataJournalIndex)

--- a/DasLog.lua
+++ b/DasLog.lua
@@ -1,7 +1,5 @@
--- local currentDate   = tonumber(GetDate())
-currentDate   = tonumber(GetDate())
-characterName = DAS.pdn or GetUnitName(UNITTAG_PLAYER)
--- local characterName = DAS.pdn or GetUnitName(UNITTAG_PLAYER)
+local currentDate = tonumber(GetDate())
+local characterName = DAS.pdn or GetUnitName(UNITTAG_PLAYER)
 local function getSettingsArray()
   currentDate   = currentDate or tonumber(GetDate())
   characterName = characterName or GetUnitName(UNITTAG_PLAYER)
@@ -25,7 +23,7 @@ function DAS.GetCompleted(questName)
 end
 function DAS.LogQuest(questName, completed)
   if not questName then return end
-  local timeStringNumber  = timeStringNumber or tonumber(GetTimeString():sub(1,2))
+  local timeStringNumber  = tonumber(GetTimeString():sub(1,2))
   local settings 	        = getSettingsArray()
   local afterEight 	= (timeStringNumber >= 8) -- 08:17:02 - reset is at 8
   local afterEightHasChanged = false


### PR DESCRIPTION
Several vars and functions were declared without the local prefix.

Also fixed: non-namespaced function calls and "Spam chat for this quest" routine for non-English clients.