### PR TITLE
Update Share button state on click

### DIFF
--- a/DASUserSettingsAdapter.lua
+++ b/DASUserSettingsAdapter.lua
@@ -162,6 +162,7 @@ function DAS.GetAutoShare()
 end
 function DAS.SetAutoShare(value)
 	DAS.GetSettings().autoShare = value
+	DAS.SetButtonStates()
 end
 function DAS.GetAutoLeave()
 	return GetSettings().autoLeave


### PR DESCRIPTION
Currently the button state doesn't get updated after clicking on 'Share', this commit fixes it.