### PR TITLE
Actually add the Hew's Bane support for realsies

### DIFF
--- a/00_startup.lua
+++ b/00_startup.lua
@@ -155,6 +155,7 @@ local defaults = {
 		[888]  = true, -- Craglorn
 		[181]  = true, -- Cyrodiil
 		[823]  = true, -- Gold Coast
+		[816]  = true, -- Hew's Bane
 		[726]  = true, -- Murkmire
 		[1086] = true, -- Northern Elsweyr
 		[1133] = true, -- Southern Elsweyr

--- a/DASMenu.lua
+++ b/DASMenu.lua
@@ -177,6 +177,13 @@ function DAS.CreateMenu(savedVars, defaults)
 				},
 				{
 					type    = "checkbox",
+					tooltip = "Thieves Guild DLC",
+					name    = "Hew's Bane",
+					getFunc = function() return DAS.GetActiveIn(816) end,
+					setFunc = function(value) DAS.SetActiveIn(816, value) end
+				},
+				{
+					type    = "checkbox",
 					tooltip = "Murkmire DLC",
 					name    = "Murkmire",
 					getFunc = function() return DAS.GetActiveIn(726) end,

--- a/locale/de.lua
+++ b/locale/de.lua
@@ -185,6 +185,25 @@ local strings  = {
 	DAS_DB_ARENA            = "Das Jubeln der Menge",    -- 5606
 
 
+	-- Hew's Bane / Thieves Guild
+	-- Heists
+	DAS_HEWS_HDEAD          = "Beutezug der Todkuhlenhallen",           -- 5536
+	DAS_HEWS_HHIDE          = "Beutezug des Verstecks",                 -- 5572
+	DAS_HEWS_HUNDE          = "Beutezug der unterirdischen Grabstätte", -- 5573
+	DAS_HEWS_HGLIT          = "Beutezug der funkelnden Grotte",         -- 5575
+	DAS_HEWS_HSECL          = "Beutezug der abgelegenen Kanalisation",  -- 5577
+	-- World Boss dailies
+	DAS_HEWS_KOEST          = "Die verschwundenen Perlen",              -- 5586
+	DAS_HEWS_THRAL          = "Sklavenbucht",                           -- 5587
+	-- Delve dailies
+	DAS_HEWS_BAHRA          = "Erinnerungen an die Jugend",             -- 5588
+	DAS_HEWS_SHARK          = "Die Seemannspfeife",                     -- 5589
+	DAS_QUEST_TG_HEIST      = "Brett für Beutezüge",                    -- 87370069-0-20019
+	DAS_QUEST_TG_REACQ      = "Brett für Rückbeschaffungen",            -- 87370069-0-20116
+	DAS_QUEST_TG_FAREN      = "Fa'ren-dar",                             -- 69599
+	DAS_QUEST_TG_SPENC      = "Spencer Rye",                            -- 69854
+
+
 	-- New Life Festival
 	DAS_NL_EASTMARCH        = "Der Schneebärensprung",               -- 5811
 	DAS_NL_REAPERSMARCH     = "Die Prüfung der Fünfkrallenlist",     -- 5834

--- a/locale/en.lua
+++ b/locale/en.lua
@@ -186,6 +186,25 @@ local strings  = {
 	DAS_DB_ARENA            = "The Roar of the Crowds", -- 5606
 
 
+	-- Hew's Bane / Thieves Guild
+	-- Heists
+	DAS_HEWS_HDEAD          = "Heist: Deadhollow Halls",      -- 5536
+	DAS_HEWS_HHIDE          = "Heist: The Hideaway",          -- 5572
+	DAS_HEWS_HUNDE          = "Heist: Underground Sepulcher", -- 5573
+	DAS_HEWS_HGLIT          = "Heist: Glittering Grotto",     -- 5575
+	DAS_HEWS_HSECL          = "Heist: Secluded Sewers",       -- 5577
+	-- World Boss dailies
+	DAS_HEWS_KOEST          = "The Lost Pearls",              -- 5586
+	DAS_HEWS_THRAL          = "Thrall Cove",                  -- 5587
+	-- Delve dailies
+	DAS_HEWS_BAHRA          = "Memories of Youth",            -- 5588
+	DAS_HEWS_SHARK          = "The Sailor's Pipe",            -- 5589
+	DAS_QUEST_TG_HEIST      = "Heist Board",                  -- 87370069-0-20019
+	DAS_QUEST_TG_REACQ      = "Reacquisition Board",          -- 87370069-0-20116
+	DAS_QUEST_TG_FAREN      = "Fa'ren-dar",                   -- 69599
+	DAS_QUEST_TG_SPENC      = "Spencer Rye",                  -- 69854
+
+
 	-- New Life Festival
 	DAS_NL_EASTMARCH        = "Snow Bear Plunge",               -- 5811
 	DAS_NL_REAPERSMARCH     = "The Trial of Five-Clawed Guile", -- 5834

--- a/locale/fr.lua
+++ b/locale/fr.lua
@@ -185,6 +185,25 @@ local strings  = {
 	DAS_DB_ARENA            = "Le hurlement des foules", -- 5606
 
 
+	-- Hew's Bane / Thieves Guild
+	-- Heists
+	DAS_HEWS_HDEAD          = "Casse : Salles du Sépulcre",     -- 5536
+	DAS_HEWS_HHIDE          = "Casse : la Cachette",            -- 5572
+	DAS_HEWS_HUNDE          = "Casse : sépulcre souterrain",    -- 5573
+	DAS_HEWS_HGLIT          = "Casse : la grotte scintillante", -- 5575
+	DAS_HEWS_HSECL          = "Casse : égouts reculés",         -- 5577
+	-- World Boss dailies
+	DAS_HEWS_KOEST          = "Les perles disparues",           -- 5586
+	DAS_HEWS_THRAL          = "Crique des esclaves",            -- 5587
+	-- Delve dailies
+	DAS_HEWS_BAHRA          = "Souvenirs d'enfance",            -- 5588
+	DAS_HEWS_SHARK          = "La pipe de marin",               -- 5589
+	DAS_QUEST_TG_HEIST      = "Affichage des casses",           -- 87370069-0-20019
+	DAS_QUEST_TG_REACQ      = "Tableau de réacquisition",       -- 87370069-0-20116
+	DAS_QUEST_TG_FAREN      = "Fa'ren-dar",                     -- 69599
+	DAS_QUEST_TG_SPENC      = "Spencer Rye",                    -- 69854
+
+
 	-- New Life Festival
 	DAS_NL_EASTMARCH        = "Le plongeon de l'ours des neiges",    -- 5811
 	DAS_NL_REAPERSMARCH     = "L'Épreuve de la Ruse à cinq griffes", -- 5834

--- a/locale/jp.lua
+++ b/locale/jp.lua
@@ -185,6 +185,25 @@ local strings  = {
 	DAS_DB_ARENA            = "群衆のどよめき", -- 5606
 
 
+	-- Hew's Bane / Thieves Guild
+	-- Heists
+	DAS_HEWS_HDEAD          = "強奪: 虚空の広間", -- 5536
+	DAS_HEWS_HHIDE          = "強奪: 隠れ場所", -- 5572
+	DAS_HEWS_HUNDE          = "強奪: 地下墓地", -- 5573
+	DAS_HEWS_HGLIT          = "強奪: グリタリング洞窟", -- 5575
+	DAS_HEWS_HSECL          = "強奪: 僻地の下水道", -- 5577
+	-- World Boss dailies
+	DAS_HEWS_KOEST          = "失われた真珠", -- 5586
+	DAS_HEWS_THRAL          = "虜囚の入り江", -- 5587
+	-- Delve dailies
+	DAS_HEWS_BAHRA          = "青春の記憶", -- 5588
+	DAS_HEWS_SHARK          = "船乗りのキセル", -- 5589
+	DAS_QUEST_TG_HEIST      = "強奪ボード", -- 87370069-0-20019
+	DAS_QUEST_TG_REACQ      = "再取得掲示板", -- 87370069-0-20116
+	DAS_QUEST_TG_FAREN      = "ファレン・ダー", -- 69599
+	DAS_QUEST_TG_SPENC      = "スペンサー・ライ", -- 69854
+
+
 	-- New Life Festival
 	DAS_NL_EASTMARCH        = "雪熊の飛び込み", -- 5811
 	DAS_NL_REAPERSMARCH     = "五つ爪の策略の試練", -- 5834

--- a/locale/ru.lua
+++ b/locale/ru.lua
@@ -185,6 +185,25 @@ local strings  = {
 	DAS_DB_ARENA            = "Рев толпы",        -- 5606
 
 
+	-- Hew's Bane / Thieves Guild
+	-- Heists
+	DAS_HEWS_HDEAD          = "Ограбление: залы Мертвой Пустоты", -- 5536
+	DAS_HEWS_HHIDE          = "Ограбление: Укрытие",              -- 5572
+	DAS_HEWS_HUNDE          = "Ограбление: подземная гробница",   -- 5573
+	DAS_HEWS_HGLIT          = "Ограбление: Сверкающий грот",      -- 5575
+	DAS_HEWS_HSECL          = "Ограбление: закрытая канализация", -- 5577
+	-- World Boss dailies
+	DAS_HEWS_KOEST          = "Потерянные жемчужины",             -- 5586
+	DAS_HEWS_THRAL          = "Бухта Рабов",                      -- 5587
+	-- Delve dailies
+	DAS_HEWS_BAHRA          = "Воспоминания о молодости",         -- 5588
+	DAS_HEWS_SHARK          = "Трубка моряка",                    -- 5589
+	DAS_QUEST_TG_HEIST      = "Доска ограблений",                 -- 87370069-0-20019
+	DAS_QUEST_TG_REACQ      = "Доска объявлений о кражах",        -- 87370069-0-20116
+	DAS_QUEST_TG_FAREN      = "Фа'рен-дар",                       -- 69599
+	DAS_QUEST_TG_SPENC      = "Спенсер Рай",                      -- 69854
+
+
 	-- New Life Festival
 	DAS_NL_EASTMARCH        = "Ныряние снежного медведя",       -- 5811
 	DAS_NL_REAPERSMARCH     = "Испытание когтистого коварства", -- 5834

--- a/questData/GoldCoast.lua
+++ b/questData/GoldCoast.lua
@@ -1,9 +1,7 @@
-local zoneId  = 823
-local zoneId2 = 824 -- Hrota Cave
-local zoneId3 = 825 -- Garlas Agea
+local zoneId = 823 -- Gold Coast
 
-DAS.subzones[zoneId2] = zoneId
-DAS.subzones[zoneId3] = zoneId
+DAS.subzones[824] = zoneId -- Hrota Cave
+DAS.subzones[825] = zoneId -- Garlas Agea
 
 DAS.shareables[zoneId] = {
 	-- World Boss dailies
@@ -11,15 +9,15 @@ DAS.shareables[zoneId] = {
 	GetString(DAS_DB_ARENA),
 	-- Delve dailies
 	GetString(DAS_DB_GOOD),
-	GetString(DAS_DB_EVIL)
+	GetString(DAS_DB_EVIL),
 }
 DAS.makeBingoTable(zoneId, {
 	-- World Boss dailies
-	{[1] = "mino", [2] = "m"},
-	{[1] = "arena",[2] = "a"},
+	{"mino", "m"},
+	{"arena","a"},
 	-- Delve dailies
-	{[1] = "good", [2] = "common", [3] = "cg"},
-	{[1] = "evil", [2] = "buried", [3] = "be"}
+	{"good", "common", "cg"},
+	{"evil", "buried", "be"},
 })
 
 DAS.questStarter[zoneId] = {
@@ -47,6 +45,3 @@ DAS.questIds[zoneId] = questIds
 for id, _ in pairs(questIds) do
 	DAS_QUEST_IDS[id] = true
 end
-
-DAS.zoneHasAdditionalId(zoneId2, zoneId)
-DAS.zoneHasAdditionalId(zoneId3, zoneId)

--- a/questData/HewsBane.lua
+++ b/questData/HewsBane.lua
@@ -1,10 +1,116 @@
-DAS.shareables 	    = DAS.shareables    or {}
-DAS.bingo 		    = DAS.bingo 	    or {}
-local zoneId	= 816
-local zoneId2	= 821
+local zoneId = 816 -- Hew's Bane
+
+DAS.subzones[676] = zoneId -- Shark's Teeth Grotto
+DAS.subzones[763] = zoneId -- Secluded Sewers
+DAS.subzones[764] = zoneId -- Underground Sepulcher
+DAS.subzones[767] = zoneId -- Deadhollow Halls
+DAS.subzones[770] = zoneId -- The Hideaway
+DAS.subzones[771] = zoneId -- Glittering Grotto
+DAS.subzones[817] = zoneId -- Bahraha's Gloom
+DAS.subzones[821] = zoneId -- Thieves Den
+
 DAS.shareables[zoneId] = {
+	-- World Boss dailies
+	GetString(DAS_HEWS_KOEST), -- The Lost Pearls, Syvarra of the Deep
+	GetString(DAS_HEWS_THRAL), -- Thrall Cove, Captain Virindi Slave-Taker
+	-- Delve dailies
+	GetString(DAS_HEWS_BAHRA), -- Memories of Youth, Bahraha's Gloom
+	GetString(DAS_HEWS_SHARK), -- The Sailor's Pipe, Shark's Teeth Grotto
+	-- Heists
+	GetString(DAS_HEWS_HDEAD), -- Heist: Deadhollow Halls
+	GetString(DAS_HEWS_HGLIT), -- Heist: Glittering Grotto
+	GetString(DAS_HEWS_HHIDE), -- Heist: The Hideaway
+	GetString(DAS_HEWS_HSECL), -- Heist: Secluded Sewers
+	GetString(DAS_HEWS_HUNDE), -- Heist: Underground Sepulcher
 }
-local tbl2 = {}
-DAS.makeBingoTable(zoneId, tbl2)
-DAS.questIds[zoneId] = {
+DAS.makeBingoTable(zoneId, {
+	-- World Boss dailies
+	{"ko", "lamia", "pearls", "syvarra"},
+	{"elf", "thrall", "virindi"},
+	-- Delve dailies
+	{"gloom", "youth", "bahraha"},
+	{"shark", "pipe"},
+	-- Heists
+	"halls",
+	"glitter",
+	"hide",
+	"sewer",
+	"sep"
+})
+
+DAS.questStarter[zoneId] = {
+	[GetString(DAS_QUEST_TG_REACQ)] = true, -- Reacquisition Board
+	[GetString(DAS_QUEST_TG_HEIST)] = true, -- Heist Board
+}
+
+DAS.questFinisher[zoneId] = {
+	[GetString(DAS_QUEST_TG_SPENC)] = true, -- Spencer Rye
+	[GetString(DAS_QUEST_TG_FAREN)] = true, -- Fa'ren-dar
+}
+
+local questIds = {
+	-- World Boss dailies
+	[5586] = true, -- The Lost Pearls
+	[5587] = true, -- Thrall Cove
+	-- Delve dailies
+	[5588] = true, -- Memories of Youth
+	[5589] = true, -- The Sailor's Pipe
+	-- Heists
+	[5536] = true, -- Heist: Deadhollow Halls
+	[5572] = true, -- Heist: The Hideaway
+	[5573] = true, -- Heist: Underground Sepulcher
+	[5575] = true, -- Heist: Glittering Grotto
+	[5577] = true, -- Heist: Secluded Sewers
+}
+
+DAS.questIds[zoneId] = questIds
+
+for id, _ in pairs(questIds) do
+	DAS_QUEST_IDS[id] = true
+end
+
+local prequestId, prequestName
+
+-- Reacquisition dailies prerequisite
+prequestId = 5531
+prequestName = GetQuestName(prequestId) -- Partners in Crime
+DAS.prequests[GetString(DAS_HEWS_KOEST)] = {
+	prequestName = prequestName,
+	prequestId   = prequestId,
+}
+DAS.prequests[GetString(DAS_HEWS_THRAL)] = {
+	prequestName = prequestName,
+	prequestId   = prequestId,
+}
+DAS.prequests[GetString(DAS_HEWS_BAHRA)] = {
+	prequestName = prequestName,
+	prequestId   = prequestId,
+}
+DAS.prequests[GetString(DAS_HEWS_SHARK)] = {
+	prequestName = prequestName,
+	prequestId   = prequestId,
+}
+
+-- Heist dailies prerequisite
+prequestId = 5582
+prequestName = GetQuestName(prequestId) -- Master of Heists
+DAS.prequests[GetString(DAS_HEWS_HDEAD)] = {
+	prequestName = prequestName,
+	prequestId   = prequestId,
+}
+DAS.prequests[GetString(DAS_HEWS_HGLIT)] = {
+	prequestName = prequestName,
+	prequestId   = prequestId,
+}
+DAS.prequests[GetString(DAS_HEWS_HHIDE)] = {
+	prequestName = prequestName,
+	prequestId   = prequestId,
+}
+DAS.prequests[GetString(DAS_HEWS_HSECL)] = {
+	prequestName = prequestName,
+	prequestId   = prequestId,
+}
+DAS.prequests[GetString(DAS_HEWS_HUNDE)] = {
+	prequestName = prequestName,
+	prequestId   = prequestId,
 }

--- a/questData/Summerset.lua
+++ b/questData/Summerset.lua
@@ -80,5 +80,3 @@ DAS.prequests[GetString(DAS_ELF_GEYSER)] = { -- Sinking Summerset
 	prequestName = GetQuestName(6165), -- The Abyssal Cabal
 	prequestId   = 6165,
 }
-
-DAS.zoneHasAdditionalId(zoneId2, zoneId)


### PR DESCRIPTION
Hew's Bane has been sitting here for a few years with nothing but a ZoneId declared. Now it has:
- World Boss quests
- Delve quests
- Heist quests
- Auto-take and auto-turn-in hooks for all official locales
- Subzone and questId hooks

Even though it doesn't net us minotaur chest pieces like that other zone, it's still in our hearts, right?

This PR also includes cosmetic subzone fixes for Gold Coast and removes an erroneous line from Summerset data.