### PR TITLE
Update APIVersion

### DIFF
--- a/DailyAutoShare.txt
+++ b/DailyAutoShare.txt
@@ -1,7 +1,7 @@
 ## Title: DailyAutoShare
 ## Author: manavortex
 ## Version: 4.0
-## APIVersion: 100035
+## APIVersion: 101031
 ## SavedVariables: DAS_Settings DAS_Globals
 ## DependsOn: LibAddonMenu-2.0 LibCustomMenu
 ## OptionalDependsOn: pchat rChat


### PR DESCRIPTION
We're not OUTDATED, we're VINTAGE, baby!

This will make ESO shut up about this add-on being ye olde. The game doesn't actively block old add-ons from working anymore, but still.