### PR TITLE
GUI Tweaks, HUD Scene injection, SecurePostHook for Focused Quest Tracker

### DIFF
--- a/00_startup.lua
+++ b/00_startup.lua
@@ -340,7 +340,8 @@ local function queueQuestRefresh()
 end
 local function hookQuestTracker()
   if FOCUSED_QUEST_TRACKER and FOCUSED_QUEST_TRACKER.ForceAssist then
-    ZO_PreHook(FOCUSED_QUEST_TRACKER, "ForceAssist", queueQuestRefresh)
+	SecurePostHook(FOCUSED_QUEST_TRACKER, "ForceAssist", queueQuestRefresh)
+	SecurePostHook(FOCUSED_QUEST_TRACKER, "AssistNext", queueQuestRefresh)
   end
 end
 --==============================
@@ -370,6 +371,7 @@ end
 --==============================
 function DailyAutoShare_Initialize(eventCode, addonName)
 	if addonName ~= DAS.name then return end
+	em:UnregisterForEvent("DailyAutoShare", EVENT_ADD_ON_LOADED)
 	DAS.settings        = ZO_SavedVars:New(             "DAS_Settings", 2, "DAS_Settings", defaults)
 	DAS.globalSettings  = ZO_SavedVars:NewAccountWide(  "DAS_Globals",  2, "DAS_Globals",  defaults)
 	DAS.globalSettings.completionLog = DAS.globalSettings.completionLog or {}
@@ -385,11 +387,7 @@ function DailyAutoShare_Initialize(eventCode, addonName)
 
 	DAS.handleLog()
 
-	zo_callLater(function() DailyAutoShare.RefreshLabels(false, true) end, 5000)
-
-	DAS.CreateMapMarkers()	
-
-	EVENT_MANAGER:UnregisterForEvent("DailyAutoShare", EVENT_ADD_ON_LOADED)
+	DAS.CreateMapMarkers()
 end
 ZO_CreateStringId("SI_BINDING_NAME_TOGGLE_DAS_GUI",  GetString(DAS_SI_TOGGLE))
 ZO_CreateStringId("SI_BINDING_NAME_TOGGLE_DAS_LIST", GetString(DAS_SI_MINIMISE))

--- a/DAS_xml.xml
+++ b/DAS_xml.xml
@@ -35,7 +35,7 @@
 							 />
 							<OnMouseEnter>	DailyAutoShare.CreateControlTooltip(self)	</OnMouseEnter>
 							<OnMouseExit>	DailyAutoShare.HideTooltip(self)			</OnMouseExit>
-							<OnMouseUp>		DasControl:SetHidden(true)					</OnMouseUp>
+							<OnMouseUp>		DAS.SetHidden(true)					</OnMouseUp>
 						</Button>
 						<Button name="DasButtonMinmax" >
 							<Dimensions x="16" y="16" />
@@ -68,14 +68,16 @@
 						</Label>
 					</Controls>
 				</Control>
-				<Tooltip name="DailyAutoShare_Tooltip" inherits="ZO_BaseTooltip" tier="1">
+				<Tooltip name="DailyAutoShare_Tooltip" inherits="ZO_BaseTooltip" tier="HIGH" level="ZO_HIGH_TIER_TOOLTIPS">
 					<Anchor point="TOPLEFT" relativeTo="DasList" relativePoint="TOPLEFT" offsetX="0" offsetY="-50"/>
 				</Tooltip>
-				<Control name="DasList" resizeToFitDescendents="true" >
+				<Control name="DasList" hidden="true" resizeToFitDescendents="true" >
+					<ResizeToFitPadding width="20" height="20" />
 					<Dimensions x="330" />
+					<DimensionConstraints minX="330" maxX="330" />
 					<Anchor point="TOPLEFT" relativeTo="DasHandle" relativePoint="BOTTOMLEFT" offsetX="0" offsetY="0" />
 					<Controls>
-						<Backdrop name="$(parent)_BG" inherits="ZO_DefaultBackdrop"><AnchorFill/></Backdrop>
+						<Backdrop name="$(parent)_BG" inherits="ZO_DefaultBackdrop" excludeFromResizeToFitExtents="true"><AnchorFill/></Backdrop>
 						<Control name="DasHeader">
 							<Anchor point="TOPLEFT" relativeTo="DasList_Backdrop" relativePoint="TOPLEFT"		offsetX="20" offsetY="15"/>
 							<Anchor point="BOTTOMRIGHT" relativeTo="DasList_Backdrop" relativePoint="TOPLEFT" 	offsetX="310" offsetY="30" />
@@ -143,16 +145,17 @@
 							</Controls>
 						</Control>
                         <Control name="DasInvisibleFooterSpacer" mouseEnabled="false" >
-                            <Dimensions y="15" />
+                            <Dimensions y="10" />
                         </Control>
                     </Controls>
 				</Control>
                 <Control name="DasSubList" hidden="true" resizeToFitDescendents="true">
                     <Dimensions x="310" />
+					<ResizeToFitPadding width="10" height="10" />
 					<Anchor point="LEFT" relativeTo="DasList" relativePoint="RIGHT" offsetX="10" offsetY="10" />
                     <Controls>
-                        <Backdrop name="$(parent)_BG" inherits="ZO_DefaultBackdrop"><AnchorFill/></Backdrop>
-                        <Button name="DasButtonHideSublist" >
+                        <Backdrop name="$(parent)_BG" inherits="ZO_DefaultBackdrop" excludeFromResizeToFitExtents="true"><AnchorFill/></Backdrop>
+                        <Button name="DasButtonHideSublist" tier="MEDIUM" >
 							<Dimensions x="20" y="20" />
 							<Anchor point="TOPRIGHT" relativeTo="DasSubList" relativePoint="TOPRIGHT" offsetX="-8"  offsetY="5"/>
 							<Textures
@@ -166,17 +169,22 @@
                 </Control>
             </Controls>
 		</TopLevelControl>
-		<Button name="Das_Label" font="ZoFontChat" text="" wrapMode="TRUNCATE"
+		<Button name="Das_Label"
 			verticalAlignment="CENTER" horizontalAlignment="LEFT" alpha="0.85" hidden="true"
-			disabled="true" virtual="true"
-            drawLayer="1">
-			<Dimensions x="350" y="30" />
+			disabled="true" virtual="true">
+			<Dimensions x="290" y="30" />
+			<DimensionConstraints minX="290" maxX="290" />
             <FontColors
                 normalColor="INTERFACE_COLOR_TYPE_TEXT_COLORS:INTERFACE_TEXT_COLOR_NORMAL"
                 pressedColor="INTERFACE_COLOR_TYPE_TEXT_COLORS:INTERFACE_TEXT_COLOR_SELECTED"
                 mouseOverColor="INTERFACE_COLOR_TYPE_TEXT_COLORS:INTERFACE_TEXT_COLOR_HIGHLIGHT"
                 disabledColor="INTERFACE_COLOR_TYPE_TEXT_COLORS:INTERFACE_TEXT_COLOR_DISABLED"
             />
+			<Controls>
+				<Label name="$(parent)_Caption" font="ZoFontChat" horizontalAlignment="LEFT" wrapMode="ELLIPSIS" verticalAlignment="CENTER">
+					<AnchorFill/>
+				</Label>
+			</Controls>
 			<OnMouseEnter>DailyAutoShare.CreateLabelTooltip(self)</OnMouseEnter>
 			<OnMouseExit>DailyAutoShare.HideTooltip(self)</OnMouseExit>
 			<OnMouseUp>DailyAutoShare.QuestLabelClicked(self, button)</OnMouseUp>


### PR DESCRIPTION
This PR should fix these two ancient glitches:
![image](https://user-images.githubusercontent.com/2910415/133906453-d3a208c4-ab4e-4c53-86d4-5f59c189a566.png)
![image](https://user-images.githubusercontent.com/2910415/133906459-a5a5063b-544f-4e93-8562-143953d22433.png)

Well, not so much 'fix' as circumvent in a different way. I've opted to instead register a callback on hud scene for "StateChange", which will setFontSize() with a 0.5s delay each time the hud scene is shown. This eliminates the quest labels pile-up on your first character load, which happened due to the HUD scene not being immediately ready and showing.

The quest 'labels' (or rather buttons) now use a child Caption control that actually houses the text now. This makes them wrap nicely with ... at the end if they overflow, and kills a few bugs with quest colours resetting on clicks.

A few layout changes were made in XML file, namely the background texture is now ignored for list size calculations, and widths were locked to the default 330, so that the overflowing labels will not affect the list's width. Close button got its own draw tier so that it's easier to click.

Finally, instead of prehooking the ForceAssist, we now secureposthook both ForceAssist and AssistNext functions of the quest tracker. [T] button presses cycling the focused quest were not tracked before, now they're captured, and update the list accordingly.