### PR TITLE
Safeguard SetGuildInviteNumber from invalid values

### DIFF
--- a/DASUserSettingsAdapter.lua
+++ b/DASUserSettingsAdapter.lua
@@ -225,7 +225,7 @@ function DAS.GetGuildInviteNumber()
 	return (tonumber(GetSettings().guildInviteNumber) or 0)
 end
 function DAS.SetGuildInviteNumber(value)
-	GetSettings().guildInviteNumber = value
+	GetSettings().guildInviteNumber = tonumber(value) or 0
 	if value ~= nil and value > 0 then
 		DAS.channelTypes[_G["CHAT_CHANNEL_GUILD_" .. value]] = true
 	end


### PR DESCRIPTION
Fixes the LUA error reported on ESOUI by Magnus:
```lua
user:/AddOns/DailyAutoShare/DASUserSettingsAdapter.lua:229: operator < is not supported for number < string
stack traceback:
user:/AddOns/DailyAutoShare/DASUserSettingsAdapter.lua:229: in function 'DAS.SetGuildInviteNumber'
user:/AddOns/DailyAutoShare/00_startup.lua:306: in function 'OnPlayerActivated'
```